### PR TITLE
makefile comments and updated .env template

### DIFF
--- a/local/.env.template
+++ b/local/.env.template
@@ -1,5 +1,4 @@
 CBORG_API_KEY=
-BIOSAMPLES_PG_DATABASE_URL=postgresql+psycopg2://username:password@localhost:5433/mydatabase
 GCP_PROJECT_NAME=
 GITHUB_TOKEN=
 OPEN_AI_KEY=


### PR DESCRIPTION
skipping conflicting reannotation code: external_metadata_awareness/biosample_duckdb_reannotation.py seems dated

look for "annotate_text" calls in other python scripts, possibly in uncommitted code on other computers?