### PR TITLE
Standardize all cache expiration to 30 days using datetime.timedelta

### DIFF
--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -14,8 +14,9 @@ BIOPORTAL_API_KEY = os.environ.get("BIOPORTAL_API_KEY")
 if not BIOPORTAL_API_KEY:
     raise Exception("Please set the BIOPORTAL_API_KEY environment variable in local/.env.")
 
-# Enable requests caching (expires after 7 days)
-requests_cache.install_cache("requests_cache", expire_after=6048000)
+# Enable requests caching (expires after 30 days)
+import datetime
+requests_cache.install_cache("requests_cache", expire_after=datetime.timedelta(days=30))
 
 converter = load_converter(["bioportal", "obo"])
 

--- a/external_metadata_awareness/new_env_triad_values_splitter.py
+++ b/external_metadata_awareness/new_env_triad_values_splitter.py
@@ -257,8 +257,9 @@ def main(host, port, db, collection, field, env_file, min_length, authenticate):
         if 'preferredPrefix' in i and len(i['preferredPrefix'].strip()) > 0:
             obo_ontology_indicators_lc.add(i['preferredPrefix'].strip().lower())
 
-    # Create a cache that lasts for 1 hour (3600 seconds)
-    requests_cache.install_cache('new_env_triad_values_splitter_cache', expire_after=3600)  # 1 hour
+    # Create a cache that lasts for 30 days
+    import datetime
+    requests_cache.install_cache('new_env_triad_values_splitter_cache', expire_after=datetime.timedelta(days=30))
 
     BIOPORTAL_API_KEY = os.getenv("BIOPORTAL_API_KEY")
 

--- a/notebooks/studies_exploration/ncbi_annotation_mining/build_and_apply_lexical_index_from_env_triad_values_ner.ipynb
+++ b/notebooks/studies_exploration/ncbi_annotation_mining/build_and_apply_lexical_index_from_env_triad_values_ner.ipynb
@@ -103,7 +103,7 @@
     }
    },
    "cell_type": "code",
-   "source": "requests_cache_expire_after = 6048000 # todo reassess",
+   "source": "requests_cache_expire_after = datetime.timedelta(days=30)",
    "id": "105bdfa02b4d695",
    "outputs": [],
    "execution_count": 6
@@ -193,7 +193,7 @@
    "cell_type": "code",
    "source": [
     "# Enable request caching\n",
-    "requests_cache.install_cache(requests_cache_name, expire_after=requests_cache_expire_after)  # Cache expires after 7 days"
+    "requests_cache.install_cache(requests_cache_name, expire_after=requests_cache_expire_after)  # Cache expires after 30 days"
    ],
    "id": "98588cfc165aac08",
    "outputs": [],

--- a/requests-caching.md
+++ b/requests-caching.md
@@ -4,32 +4,24 @@ This document lists all places where requests caches are used in the codebase:
 
 1. **new_env_triad_ols_annotator.py**
    - Cache name: `"requests_cache"`
-   - Expiration time: 6,048,000 seconds (70 days)
-   - Line 25: `requests_cache.install_cache("requests_cache", expire_after=6048000)`
+   - Expiration time: 30 days
+   - Line 26: `requests_cache.install_cache("requests_cache", expire_after=datetime.timedelta(days=30))`
 
 2. **new_bioportal_curie_mapper.py**
    - Cache name: `"requests_cache"`
-   - Expiration time: 6,048,000 seconds (70 days)
-   - Line 16: `requests_cache.install_cache("requests_cache", expire_after=6048000)`
+   - Expiration time: 30 days
+   - Line 19: `requests_cache.install_cache("requests_cache", expire_after=datetime.timedelta(days=30))`
 
 3. **new_env_triad_values_splitter.py**
    - Cache name: `"new_env_triad_values_splitter_cache"`
-   - Expiration time: 3,600 seconds (1 hour)
-   - Line 247: `requests_cache.install_cache('new_env_triad_values_splitter_cache', expire_after=3600)`
+   - Expiration time: 30 days
+   - Line 237: `requests_cache.install_cache('new_env_triad_values_splitter_cache', expire_after=datetime.timedelta(days=30))`
 
-4. **new_env_triad_values_splitter.ipynb**
-   - Cache name: `"my_cache"`
-   - Expiration time: 3,600 seconds (1 hour)
-   - Cell 27: `requests_cache.install_cache('my_cache', expire_after=3600)`
-
-5. **build_and_apply_lexical_index_from_env_triad_values_ner.py**
+4. **build_and_apply_lexical_index_from_env_triad_values_ner.ipynb**
    - Cache name: `"requests_cache"`
-   - Expiration time: 6,048,000 seconds (70 days)
-   - Line 88: `requests_cache.install_cache(requests_cache_name, expire_after=requests_cache_expire_after)`
-   - The variable `requests_cache_name` is set to `"requests_cache"` and `requests_cache_expire_after` is set to `6048000`
-
-6. **build_and_apply_lexical_index_from_env_triad_values_ner.ipynb**
-   - Cache name: `"requests_cache"`
-   - Expiration time: 6,048,000 seconds (70 days)
+   - Expiration time: 30 days
    - Cell 9: `requests_cache.install_cache(requests_cache_name, expire_after=requests_cache_expire_after)`
-   - The variable `requests_cache_name` is set to `"requests_cache"` and `requests_cache_expire_after` is set to `6048000`
+   - The variable `requests_cache_name` is set to `"requests_cache"` and `requests_cache_expire_after` is set to `datetime.timedelta(days=30)`
+
+> Note: All cache periods have been standardized to 30 days using the `datetime.timedelta` approach for consistency.
+> The notebook file **new_env_triad_values_splitter.ipynb** mentioned previously was not found in the repository.


### PR DESCRIPTION
- Update all requests_cache timeouts to use a consistent 30 days expiration
- Change from seconds-based expiration to more readable datetime.timedelta
- Update requests-caching.md documentation to reflect changes
- Standardize across all scripts and notebooks