### PR TITLE
Add SQL script for DuckDB SRA biosample-bioproject pairs

### DIFF
--- a/sql/create_sra_biosample_bioproject_pairs.sql
+++ b/sql/create_sra_biosample_bioproject_pairs.sql
@@ -1,0 +1,28 @@
+-- Create sra_biosamples_bioprojects table from SRA metadata parquet files
+-- This replicates the MongoDB aggregation in extract_sra_biosample_bioproject_pairs_simple.js
+
+-- Create table with distinct biosample-bioproject pairs
+CREATE OR REPLACE TABLE sra_biosamples_bioprojects AS
+SELECT DISTINCT 
+    biosample AS biosample_accession,
+    bioproject AS bioproject_accession
+FROM read_parquet('downloads/sra_metadata_parquet/*')
+WHERE biosample IS NOT NULL 
+  AND bioproject IS NOT NULL
+  AND biosample != ''
+  AND bioproject != '';
+
+-- Create indexes for query performance
+CREATE INDEX idx_biosample ON sra_biosamples_bioprojects(biosample_accession);
+CREATE INDEX idx_bioproject ON sra_biosamples_bioprojects(bioproject_accession);
+CREATE INDEX idx_compound ON sra_biosamples_bioprojects(biosample_accession, bioproject_accession);
+
+-- Show summary statistics
+SELECT 
+    COUNT(*) as total_pairs,
+    COUNT(DISTINCT biosample_accession) as unique_biosamples,
+    COUNT(DISTINCT bioproject_accession) as unique_bioprojects
+FROM sra_biosamples_bioprojects;
+
+-- Show first few records as verification
+SELECT * FROM sra_biosamples_bioprojects LIMIT 10;


### PR DESCRIPTION
This SQL script replicates the functionality of the MongoDB aggregation in extract_sra_biosample_bioproject_pairs_simple.js but uses parquet files as the data source instead of MongoDB collections.

- Creates sra_biosamples_bioprojects table from SRA metadata parquet files
- Extracts distinct biosample-bioproject pairs with proper filtering
- Includes performance indexes and summary statistics
- Provides DuckDB SQL alternative to MongoDB-based relationship extraction

🤖 Generated with [Claude Code](https://claude.ai/code)