### PR TITLE
Add atomic, resumable biosample counting targets

### DIFF
--- a/mongo-js/count_biosamples_per_hn_step1.js
+++ b/mongo-js/count_biosamples_per_hn_step1.js
@@ -1,0 +1,57 @@
+// Step 1: Dedupe harmonized_name + accession → count biosamples per harmonized_name
+// Input: biosamples_attributes → Output: __tmp_hn_counts
+// Part of atomic biosample counting workflow (Issue #237)
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 1: Counting biosamples per harmonized_name (dedupe)`);
+
+// Check if already done
+const existingCount = db.__tmp_hn_counts.estimatedDocumentCount();
+if (existingCount > 0) {
+    print(`[${new Date().toISOString()}] ✓ Step 1 already complete (__tmp_hn_counts has ${existingCount} records)`);
+    print(`[${new Date().toISOString()}] Skipping - delete __tmp_hn_counts to rerun`);
+    quit(0);
+}
+
+// Drop output collection
+db.__tmp_hn_counts.drop();
+
+// Deduplicate harmonized_name + accession pairs and count
+print(`[${new Date().toISOString()}] Running aggregation (may take 30-60 min for 712M records)...`);
+db.biosamples_attributes.aggregate([
+    {
+        $match: {
+            harmonized_name: { $type: "string", $ne: "" },
+            accession: { $type: "string", $ne: "" }
+        }
+    },
+    {
+        $group: {
+            _id: { h: "$harmonized_name", a: "$accession" }
+        }
+    },
+    {
+        $group: {
+            _id: "$_id.h",
+            biosample_count: { $sum: 1 }
+        }
+    },
+    {
+        $project: {
+            _id: 0,
+            harmonized_name: "$_id",
+            biosample_count: 1
+        }
+    },
+    {
+        $out: "__tmp_hn_counts"
+    }
+], { allowDiskUse: true });
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.__tmp_hn_counts.countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 1 complete`);
+print(`[${endTime.toISOString()}] Created ${resultCount} records in __tmp_hn_counts`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds`);

--- a/mongo-js/count_biosamples_per_hn_step2.js
+++ b/mongo-js/count_biosamples_per_hn_step2.js
@@ -1,0 +1,88 @@
+// Step 2: Count totals and unit coverage per harmonized_name
+// Input: biosamples_attributes → Output: __tmp_hn_totals
+// Part of atomic biosample counting workflow (Issue #237)
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 2: Counting totals and unit coverage per harmonized_name`);
+
+// Check if already done
+const existingCount = db.__tmp_hn_totals.estimatedDocumentCount();
+if (existingCount > 0) {
+    print(`[${new Date().toISOString()}] ✓ Step 2 already complete (__tmp_hn_totals has ${existingCount} records)`);
+    print(`[${new Date().toISOString()}] Skipping - delete __tmp_hn_totals to rerun`);
+    quit(0);
+}
+
+// Drop output collection
+db.__tmp_hn_totals.drop();
+
+// Count total attributes and unit coverage per harmonized_name
+print(`[${new Date().toISOString()}] Running aggregation (may take 15-30 min for 712M records)...`);
+db.biosamples_attributes.aggregate([
+    {
+        $match: {
+            harmonized_name: { $type: "string", $ne: "" }
+        }
+    },
+    {
+        $group: {
+            _id: "$harmonized_name",
+            total_attribute_records: { $sum: 1 },
+            has_unit_records: {
+                $sum: {
+                    $cond: [
+                        {
+                            $and: [
+                                { $ne: ["$unit", null] },
+                                { $ne: ["$unit", ""] }
+                            ]
+                        },
+                        1,
+                        0
+                    ]
+                }
+            }
+        }
+    },
+    {
+        $project: {
+            _id: 0,
+            harmonized_name: "$_id",
+            total_attribute_records: 1,
+            has_unit_records: 1,
+            unit_coverage_percent: {
+                $cond: [
+                    { $gt: ["$total_attribute_records", 0] },
+                    {
+                        $round: [
+                            {
+                                $multiply: [
+                                    {
+                                        $divide: [
+                                            "$has_unit_records",
+                                            "$total_attribute_records"
+                                        ]
+                                    },
+                                    100
+                                ]
+                            },
+                            2
+                        ]
+                    },
+                    0
+                ]
+            }
+        }
+    },
+    {
+        $out: "__tmp_hn_totals"
+    }
+], { allowDiskUse: true });
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.__tmp_hn_totals.countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 2 complete`);
+print(`[${endTime.toISOString()}] Created ${resultCount} records in __tmp_hn_totals`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds`);

--- a/mongo-js/count_biosamples_per_hn_step3.js
+++ b/mongo-js/count_biosamples_per_hn_step3.js
@@ -1,0 +1,117 @@
+// Step 3: Join temp tables and create final harmonized_name_biosample_counts collection
+// Input: __tmp_hn_counts + __tmp_hn_totals → Output: harmonized_name_biosample_counts
+// Part of atomic biosample counting workflow (Issue #237)
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 3: Joining temp tables and creating final collection`);
+
+// Check if already done
+const existingCount = db.harmonized_name_biosample_counts.estimatedDocumentCount();
+if (existingCount > 0) {
+    print(`[${new Date().toISOString()}] ✓ Step 3 already complete (harmonized_name_biosample_counts has ${existingCount} records)`);
+    print(`[${new Date().toISOString()}] Skipping - delete harmonized_name_biosample_counts to rerun`);
+    quit(0);
+}
+
+// Check prerequisites
+const countsExist = db.__tmp_hn_counts.estimatedDocumentCount();
+const totalsExist = db.__tmp_hn_totals.estimatedDocumentCount();
+
+if (countsExist === 0) {
+    print(`[${new Date().toISOString()}] ERROR: __tmp_hn_counts is empty - run Step 1 first`);
+    quit(1);
+}
+if (totalsExist === 0) {
+    print(`[${new Date().toISOString()}] ERROR: __tmp_hn_totals is empty - run Step 2 first`);
+    quit(1);
+}
+
+print(`[${new Date().toISOString()}] Prerequisites met (__tmp_hn_counts: ${countsExist}, __tmp_hn_totals: ${totalsExist})`);
+
+// Get total unique accessions for coverage calculation
+print(`[${new Date().toISOString()}] Calculating total unique accessions...`);
+const totalUniqueAccessions = db.biosamples_attributes.aggregate([
+    { $match: { accession: { $type: "string", $ne: "" } } },
+    { $group: { _id: "$accession" } },
+    { $count: "total" }
+], { allowDiskUse: true }).toArray()[0]?.total ?? 0;
+
+print(`[${new Date().toISOString()}] Total unique accessions: ${totalUniqueAccessions.toLocaleString()}`);
+
+// Drop output collection
+db.harmonized_name_biosample_counts.drop();
+
+// Join temp tables
+print(`[${new Date().toISOString()}] Joining temp tables (may take 5-10 min)...`);
+db.__tmp_hn_counts.aggregate([
+    {
+        $lookup: {
+            from: "__tmp_hn_totals",
+            localField: "harmonized_name",
+            foreignField: "harmonized_name",
+            as: "t"
+        }
+    },
+    {
+        $unwind: {
+            path: "$t",
+            preserveNullAndEmptyArrays: true
+        }
+    },
+    {
+        $addFields: {
+            total_attribute_records: "$t.total_attribute_records",
+            has_unit_records: "$t.has_unit_records",
+            unit_coverage_percent: "$t.unit_coverage_percent",
+            coverage_percent: {
+                $cond: [
+                    { $gt: [totalUniqueAccessions, 0] },
+                    {
+                        $round: [
+                            {
+                                $multiply: [
+                                    {
+                                        $divide: [
+                                            "$biosample_count",
+                                            totalUniqueAccessions
+                                        ]
+                                    },
+                                    100
+                                ]
+                            },
+                            2
+                        ]
+                    },
+                    0
+                ]
+            }
+        }
+    },
+    {
+        $project: {
+            t: 0
+        }
+    },
+    {
+        $sort: {
+            biosample_count: -1
+        }
+    },
+    {
+        $out: "harmonized_name_biosample_counts"
+    }
+], { allowDiskUse: true });
+
+// Create indexes
+print(`[${new Date().toISOString()}] Creating indexes on harmonized_name_biosample_counts...`);
+db.harmonized_name_biosample_counts.createIndex({ harmonized_name: 1 });
+db.harmonized_name_biosample_counts.createIndex({ biosample_count: -1 });
+db.harmonized_name_biosample_counts.createIndex({ unit_coverage_percent: -1 });
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.harmonized_name_biosample_counts.countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 3 complete`);
+print(`[${endTime.toISOString()}] Created harmonized_name_biosample_counts with ${resultCount} records`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds`);


### PR DESCRIPTION
## Summary

Fixes #237 - Breaks monolithic biosample counting into 3 small, independent, resumable steps.

## Problem

The existing `count_biosamples_per_harmonized_name.js` script:
- 140+ lines of monolithic JavaScript
- Takes 1-1.5 hours to process 712M records
- No intermediate checkpoints
- Must restart from scratch if any step fails
- Difficult to debug

## Solution

Three small JavaScript files + Make targets:

### Step 1: Dedupe (30-60 min)
```bash
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-hn-step1
```
- Deduplicates 712M harmonized_name + accession pairs
- Counts biosamples per harmonized_name
- Output: `__tmp_hn_counts` collection

### Step 2: Totals (15-30 min)
```bash
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-hn-step2
```
- Counts total attributes and unit coverage per harmonized_name
- Output: `__tmp_hn_totals` collection

### Step 3: Join (5-10 min)
```bash
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-hn-step3
```
- Joins temp collections
- Creates final `harmonized_name_biosample_counts` collection
- Creates indexes

### Meta-target (run all 3)
```bash
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-harmonized-name-atomic
```

## Benefits

✅ **Resumable**: Each step checks if output exists, skips if complete  
✅ **Debuggable**: Can inspect temp collections between steps  
✅ **Small files**: 60-120 lines each, not 140+ monolith  
✅ **No inline JS**: Follows repo pattern of separate `.js` files  
✅ **Independent**: Can re-run individual steps

## Files Changed

- `mongo-js/count_biosamples_per_hn_step1.js` (new)
- `mongo-js/count_biosamples_per_hn_step2.js` (new)
- `mongo-js/count_biosamples_per_hn_step3.js` (new)
- `Makefiles/measurement_discovery.Makefile` (added targets)

## Test Plan

On NUC with 712M biosamples_attributes records:
```bash
cd ~/gitrepos/external-metadata-awareness
git pull
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-hn-step1
# Wait for completion, inspect __tmp_hn_counts
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-hn-step2
# Wait for completion, inspect __tmp_hn_totals  
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-hn-step3
# Verify harmonized_name_biosample_counts created
```

Or run all at once:
```bash
make -f Makefiles/measurement_discovery.Makefile count-biosamples-per-harmonized-name-atomic
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)