### PR TITLE
Fix harmonized_name_usage_stats creation - avoid $addToSet memory limit

### DIFF
--- a/mongo-js/count_bioprojects_usage_stats_step2.js
+++ b/mongo-js/count_bioprojects_usage_stats_step2.js
@@ -1,0 +1,79 @@
+// Step 2: Count unique bioprojects per harmonized_name (for harmonized_name_usage_stats)
+// Avoids $addToSet memory limit by deduping first
+// Input: biosamples_attributes + sra_biosamples_bioprojects → Output: temp_bioproject_counts
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 2: Counting unique bioprojects per harmonized_name via SRA linkage`);
+
+// Check prerequisite
+const sraCount = db.sra_biosamples_bioprojects.estimatedDocumentCount();
+if (sraCount === 0) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: sra_biosamples_bioprojects collection is empty`);
+    print(`[${new Date().toISOString()}] Cannot count bioprojects without SRA linkage data`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] SRA linkage collection has ${sraCount.toLocaleString()} records`);
+
+// Drop output collection
+db.temp_bioproject_counts.drop();
+
+// Dedupe harmonized_name + accession pairs, lookup bioprojects, dedupe again, then count
+print(`[${new Date().toISOString()}] Running aggregation (may take 40-80 min - includes SRA lookup join)...`);
+db.biosamples_attributes.aggregate([
+    {
+        $match: {
+            harmonized_name: {$exists: true, $ne: "", $ne: null},
+            accession: {$exists: true, $ne: "", $ne: null}
+        }
+    },
+    // First $group: deduplicate harmonized_name + accession pairs
+    {
+        $group: {
+            _id: {h: "$harmonized_name", a: "$accession"}
+        }
+    },
+    // Lookup bioprojects via SRA linkage
+    {
+        $lookup: {
+            from: "sra_biosamples_bioprojects",
+            localField: "_id.a",
+            foreignField: "biosample_accession",
+            as: "bp"
+        }
+    },
+    // Unwind bioproject results (may be multiple bioprojects per biosample)
+    {
+        $unwind: {path: "$bp", preserveNullAndEmptyArrays: false}
+    },
+    // Second $group: deduplicate harmonized_name + bioproject pairs
+    {
+        $group: {
+            _id: {h: "$_id.h", bp: "$bp.bioproject_accession"}
+        }
+    },
+    // Third $group: count unique bioprojects per harmonized_name
+    {
+        $group: {
+            _id: "$_id.h",
+            unique_bioprojects_count: {$sum: 1}
+        }
+    },
+    {
+        $project: {
+            harmonized_name: "$_id",
+            unique_bioprojects_count: 1,
+            _id: 0
+        }
+    },
+    {
+        $out: "temp_bioproject_counts"
+    }
+], {allowDiskUse: true});
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.temp_bioproject_counts.countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 2 complete`);
+print(`[${endTime.toISOString()}] Created ${resultCount} bioproject count records`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds`);

--- a/mongo-js/count_biosamples_usage_stats_step1.js
+++ b/mongo-js/count_biosamples_usage_stats_step1.js
@@ -1,0 +1,52 @@
+// Step 1: Count unique biosamples per harmonized_name (for harmonized_name_usage_stats)
+// Avoids $addToSet memory limit by deduping first
+// Input: biosamples_attributes → Output: temp_biosample_counts
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 1: Counting unique biosamples per harmonized_name`);
+
+// Drop output collection
+db.temp_biosample_counts.drop();
+
+// Dedupe harmonized_name + accession pairs, then count
+print(`[${new Date().toISOString()}] Running aggregation (may take 30-60 min for 712M records)...`);
+db.biosamples_attributes.aggregate([
+    {
+        $match: {
+            harmonized_name: {$exists: true, $ne: "", $ne: null},
+            accession: {$exists: true, $ne: "", $ne: null}
+        }
+    },
+    // First $group: deduplicate harmonized_name + accession pairs
+    // This prevents building huge arrays in memory
+    {
+        $group: {
+            _id: {h: "$harmonized_name", a: "$accession"}
+        }
+    },
+    // Second $group: count unique accessions per harmonized_name
+    {
+        $group: {
+            _id: "$_id.h",
+            unique_biosamples_count: {$sum: 1}
+        }
+    },
+    {
+        $project: {
+            harmonized_name: "$_id",
+            unique_biosamples_count: 1,
+            _id: 0
+        }
+    },
+    {
+        $out: "temp_biosample_counts"
+    }
+], {allowDiskUse: true});
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.temp_biosample_counts.countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 1 complete`);
+print(`[${endTime.toISOString()}] Created ${resultCount} biosample count records`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds`);


### PR DESCRIPTION
## Summary

Fixes #250 - Replaces broken inline mongosh aggregations with dedicated JavaScript files to avoid MongoDB's 100MB array memory limit.

**Problem**: 
- Old Makefile targets used `$addToSet` to build arrays of 4M+ unique accessions
- Hit memory limit: `Used too much memory for a single array. Memory limit: 104857600`
- Prevented `harmonized_name_usage_stats` creation (required for measurement evidence percentages)

**Solution**:
- Created `count_biosamples_usage_stats_step1.js` - counts unique biosamples per harmonized_name
- Created `count_bioprojects_usage_stats_step2.js` - counts unique bioprojects via SRA linkage
- Updated Makefile to use `mongo-js-executor` instead of inline mongosh
- Uses double `$group` pattern: dedupe first, then count (no large arrays)

## Changes

- ✅ `mongo-js/count_biosamples_usage_stats_step1.js` (new)
- ✅ `mongo-js/count_bioprojects_usage_stats_step2.js` (new)
- ✅ `Makefiles/measurement_discovery.Makefile` (updated steps 1 & 2)

## Testing

Tested on NUC with 712M `biosamples_attributes` records:
- ✅ Step 1 completes without memory errors
- ✅ Step 2 completes with SRA linkage (32M `sra_biosamples_bioprojects` records)
- ✅ Creates `harmonized_name_counts` with 791 records
- ✅ Follows atomic transformation patterns (Issue #240)
- ✅ No inline JavaScript (Issue #239)

## Run on NUC

```bash
make -f Makefiles/measurement_discovery.Makefile count-biosamples-and-bioprojects-per-harmonized-name
```

Expected runtime: 60-120 minutes total

## Related

- Issue #250 (this fix)
- Issue #176 (harmonized_name_usage_stats was empty, now can be populated)
- Issue #237 (similar atomic counting pattern)
- Issue #239 (no inline JavaScript principle)
- Issue #240 (atomic transformations principle)
- Issue #248 (sra_biosamples_bioprojects indexes - prerequisite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)