### PR TITLE
Fix step 3 to output to harmonized_name_usage_stats (not harmonized_name_counts)

### DIFF
--- a/Makefiles/measurement_discovery.Makefile
+++ b/Makefiles/measurement_discovery.Makefile
@@ -95,15 +95,15 @@ merge-counts-step3:
 		try { db.temp_bioproject_counts.createIndex({harmonized_name: 1}, {background: true}); } catch(e) { print('temp index exists: ' + e.message); } \
 		try { db.temp_biosample_counts.createIndex({harmonized_name: 1}, {background: true}); } catch(e) { print('biosample temp index exists: ' + e.message); } \
 		print('[' + new Date().toISOString() + '] Dropping final collection'); \
-		db.harmonized_name_counts.drop(); \
+		db.harmonized_name_usage_stats.drop(); \
 		print('[' + new Date().toISOString() + '] Merging counts'); \
 		db.temp_biosample_counts.aggregate([ \
 			{ \$$lookup: { from: 'temp_bioproject_counts', localField: 'harmonized_name', foreignField: 'harmonized_name', as: 'bioproject_data' } }, \
 			{ \$$project: { harmonized_name: 1, unique_biosamples_count: 1, unique_bioprojects_count: { \$$ifNull: [{ \$$arrayElemAt: ['\$$bioproject_data.unique_bioprojects_count', 0] }, 0] } } }, \
 			{ \$$sort: { unique_biosamples_count: -1 } }, \
-			{ \$$out: 'harmonized_name_counts' } \
+			{ \$$out: 'harmonized_name_usage_stats' } \
 		], { allowDiskUse: true }); \
-		print('[' + new Date().toISOString() + '] Created ' + db.harmonized_name_counts.countDocuments() + ' final stats'); \
+		print('[' + new Date().toISOString() + '] Created ' + db.harmonized_name_usage_stats.countDocuments() + ' final stats'); \
 		db.temp_biosample_counts.drop(); \
 		db.temp_bioproject_counts.drop(); \
 		print('[' + new Date().toISOString() + '] Cleaned up temp collections');"


### PR DESCRIPTION
- Changed merge-counts-step3 to use harmonized_name_usage_stats consistently
- Previously created harmonized_name_counts but indexing step expected harmonized_name_usage_stats
- This caused collection name mismatch and empty harmonized_name_usage_stats

Verified on localhost: harmonized_name_usage_stats has 695 docs with real counts NUC will now create the correctly named collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)