### PR TITLE
Break Step 2 bioproject counting into 4 atomic sub-steps

### DIFF
--- a/mongo-js/count_bioprojects_step2a_dedupe_accessions.js
+++ b/mongo-js/count_bioprojects_step2a_dedupe_accessions.js
@@ -1,0 +1,52 @@
+// Step 2a: Deduplicate harmonized_name + accession pairs from biosamples_attributes
+// Creates intermediate collection to make SRA lookup faster
+// Input: biosamples_attributes → Output: __tmp_hn_accessions
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 2a: Deduplicating harmonized_name + accession pairs`);
+
+// Check if already done
+const existingCount = db.getCollection("__tmp_hn_accessions").estimatedDocumentCount();
+if (existingCount > 0) {
+    print(`[${new Date().toISOString()}] ✓ Step 2a already complete (__tmp_hn_accessions has ${existingCount.toLocaleString()} records)`);
+    print(`[${new Date().toISOString()}] Skipping - drop __tmp_hn_accessions to rerun`);
+    quit(0);
+}
+
+// Drop output collection
+db.getCollection("__tmp_hn_accessions").drop();
+
+print(`[${new Date().toISOString()}] Running aggregation (may take 60-90 min for 712M records)...`);
+db.biosamples_attributes.aggregate([
+    {
+        $match: {
+            harmonized_name: {$exists: true, $ne: "", $ne: null},
+            accession: {$exists: true, $ne: "", $ne: null}
+        }
+    },
+    // Deduplicate harmonized_name + accession pairs
+    {
+        $group: {
+            _id: {h: "$harmonized_name", a: "$accession"}
+        }
+    },
+    {
+        $project: {
+            harmonized_name: "$_id.h",
+            accession: "$_id.a",
+            _id: 0
+        }
+    },
+    {
+        $out: "__tmp_hn_accessions"
+    }
+], {allowDiskUse: true});
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.getCollection("__tmp_hn_accessions").countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 2a complete`);
+print(`[${endTime.toISOString()}] Created ${resultCount.toLocaleString()} unique harmonized_name+accession pairs`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds (${(elapsed/60).toFixed(1)} minutes)`);
+print(`[${endTime.toISOString()}] Reduced 712M records → ${resultCount.toLocaleString()} unique pairs`);

--- a/mongo-js/count_bioprojects_step2b_index_temp.js
+++ b/mongo-js/count_bioprojects_step2b_index_temp.js
@@ -1,0 +1,29 @@
+// Step 2b: Create index on __tmp_hn_accessions for fast SRA lookup
+// Input: __tmp_hn_accessions → Output: indexed __tmp_hn_accessions
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 2b: Creating index on __tmp_hn_accessions.accession`);
+
+// Check prerequisite
+const tempCount = db.getCollection("__tmp_hn_accessions").estimatedDocumentCount();
+if (tempCount === 0) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: __tmp_hn_accessions is empty`);
+    print(`[${new Date().toISOString()}] Run Step 2a first`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] __tmp_hn_accessions has ${tempCount.toLocaleString()} records`);
+
+// Create index (critical for fast lookup)
+print(`[${new Date().toISOString()}] Creating index (may take 5-10 min)...`);
+db.getCollection("__tmp_hn_accessions").createIndex({accession: 1}, {background: true});
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+
+print(`[${endTime.toISOString()}] ✅ Step 2b complete`);
+print(`[${endTime.toISOString()}] Index created in ${elapsed} seconds`);
+
+// Verify index exists
+const indexes = db.getCollection("__tmp_hn_accessions").getIndexes();
+const hasIndex = indexes.some(idx => idx.key.accession);
+print(`[${endTime.toISOString()}] Verification: accession index ${hasIndex ? '✅ EXISTS' : '❌ MISSING'}`);

--- a/mongo-js/count_bioprojects_step2c_sra_join.js
+++ b/mongo-js/count_bioprojects_step2c_sra_join.js
@@ -1,0 +1,108 @@
+// Step 2c: Join __tmp_hn_accessions with SRA and count unique bioprojects per harmonized_name
+// Input: __tmp_hn_accessions + sra_biosamples_bioprojects → Output: temp_bioproject_counts
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 2c: Joining with SRA and counting bioprojects`);
+
+// Check prerequisites
+const tempCount = db.getCollection("__tmp_hn_accessions").estimatedDocumentCount();
+if (tempCount === 0) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: __tmp_hn_accessions is empty`);
+    print(`[${new Date().toISOString()}] Run Step 2a first`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] __tmp_hn_accessions has ${tempCount.toLocaleString()} records`);
+
+const sraCount = db.sra_biosamples_bioprojects.estimatedDocumentCount();
+if (sraCount === 0) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: sra_biosamples_bioprojects is empty`);
+    print(`[${new Date().toISOString()}] Cannot count bioprojects without SRA linkage`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] sra_biosamples_bioprojects has ${sraCount.toLocaleString()} records`);
+
+// Verify critical indexes exist
+print(`[${new Date().toISOString()}] Verifying indexes...`);
+const tempIndexes = db.getCollection("__tmp_hn_accessions").getIndexes();
+const hasTempIndex = tempIndexes.some(idx => idx.key.accession);
+if (!hasTempIndex) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: __tmp_hn_accessions.accession index missing`);
+    print(`[${new Date().toISOString()}] Run Step 2b first`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] ✅ __tmp_hn_accessions.accession index exists`);
+
+const sraIndexes = db.sra_biosamples_bioprojects.getIndexes();
+const hasSraIndex = sraIndexes.some(idx => idx.key.biosample_accession);
+if (!hasSraIndex) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: sra_biosamples_bioprojects.biosample_accession index missing`);
+    print(`[${new Date().toISOString()}] This index is critical for performance`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] ✅ sra_biosamples_bioprojects.biosample_accession index exists`);
+
+// Check if already done
+const existingCount = db.temp_bioproject_counts.estimatedDocumentCount();
+if (existingCount > 0) {
+    print(`[${new Date().toISOString()}] ✓ Step 2c already complete (temp_bioproject_counts has ${existingCount} records)`);
+    print(`[${new Date().toISOString()}] Skipping - drop temp_bioproject_counts to rerun`);
+    quit(0);
+}
+
+// Drop output collection
+db.temp_bioproject_counts.drop();
+
+print(`[${new Date().toISOString()}] Running SRA join aggregation (may take 20-40 min)...`);
+db.getCollection("__tmp_hn_accessions").aggregate([
+    // Lookup bioprojects via SRA linkage (fast because both collections are indexed)
+    {
+        $lookup: {
+            from: "sra_biosamples_bioprojects",
+            localField: "accession",
+            foreignField: "biosample_accession",
+            as: "bp"
+        }
+    },
+    // Unwind bioproject results (may be multiple bioprojects per biosample)
+    {
+        $unwind: {path: "$bp", preserveNullAndEmptyArrays: false}
+    },
+    // Extract fields we need
+    {
+        $project: {
+            harmonized_name: 1,
+            bioproject_accession: "$bp.bioproject_accession"
+        }
+    },
+    // Deduplicate harmonized_name + bioproject pairs
+    {
+        $group: {
+            _id: {h: "$harmonized_name", bp: "$bioproject_accession"}
+        }
+    },
+    // Count unique bioprojects per harmonized_name
+    {
+        $group: {
+            _id: "$_id.h",
+            unique_bioprojects_count: {$sum: 1}
+        }
+    },
+    {
+        $project: {
+            harmonized_name: "$_id",
+            unique_bioprojects_count: 1,
+            _id: 0
+        }
+    },
+    {
+        $out: "temp_bioproject_counts"
+    }
+], {allowDiskUse: true});
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+const resultCount = db.temp_bioproject_counts.countDocuments();
+
+print(`[${endTime.toISOString()}] ✅ Step 2c complete`);
+print(`[${endTime.toISOString()}] Created ${resultCount} bioproject count records`);
+print(`[${endTime.toISOString()}] Elapsed: ${elapsed} seconds (${(elapsed/60).toFixed(1)} minutes)`);

--- a/mongo-js/count_bioprojects_step2d_cleanup.js
+++ b/mongo-js/count_bioprojects_step2d_cleanup.js
@@ -1,0 +1,31 @@
+// Step 2d: Cleanup intermediate __tmp_hn_accessions collection
+// Input: __tmp_hn_accessions → Output: (deleted)
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Step 2d: Cleaning up intermediate collection`);
+
+// Check if temp_bioproject_counts was created (Step 2c completed)
+const outputCount = db.temp_bioproject_counts.estimatedDocumentCount();
+if (outputCount === 0) {
+    print(`[${new Date().toISOString()}] ⚠️  WARNING: temp_bioproject_counts is empty`);
+    print(`[${new Date().toISOString()}] Step 2c may not have completed successfully`);
+    print(`[${new Date().toISOString()}] Not dropping __tmp_hn_accessions (may need for debugging)`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] temp_bioproject_counts has ${outputCount} records - Step 2c completed`);
+
+// Check if temp collection exists
+const tempCount = db.getCollection("__tmp_hn_accessions").estimatedDocumentCount();
+if (tempCount === 0) {
+    print(`[${new Date().toISOString()}] __tmp_hn_accessions already dropped or empty`);
+    quit(0);
+}
+print(`[${new Date().toISOString()}] __tmp_hn_accessions has ${tempCount.toLocaleString()} records`);
+
+// Drop intermediate collection
+print(`[${new Date().toISOString()}] Dropping __tmp_hn_accessions...`);
+db.getCollection("__tmp_hn_accessions").drop();
+
+const endTime = new Date();
+print(`[${endTime.toISOString()}] ✅ Step 2d complete`);
+print(`[${endTime.toISOString()}] Intermediate collection cleaned up`);


### PR DESCRIPTION
Replaces the slow single-file approach that hung for 8+ hours with a 4-step atomic pipeline that uses intermediate temp collections and explicit index verification:

- Step 2a: Dedupe 712M biosamples_attributes to unique hn+accession pairs → Outputs to __tmp_hn_accessions temp collection → Reduces dataset size for faster join

- Step 2b: Create index on __tmp_hn_accessions.accession → Critical for SRA join performance

- Step 2c: Join with SRA and count bioprojects → Explicitly verifies both indexes exist before running → Uses indexed collections for fast lookup → Outputs to temp_bioproject_counts

- Step 2d: Cleanup intermediate __tmp_hn_accessions → Only drops if Step 2c completed successfully → Preserves temp collection for debugging if needed

Each sub-step has:
- Skip logic (checks if already done)
- Prerequisite validation
- Clear error messages
- Timing information

Related to #240 (atomic transformations) and #239 (JavaScript files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)