### PR TITLE
Fix unit coverage calculation to correctly handle null values

### DIFF
--- a/mongo-js/count_biosamples_per_hn_step2.js
+++ b/mongo-js/count_biosamples_per_hn_step2.js
@@ -33,7 +33,8 @@ db.biosamples_attributes.aggregate([
                     $cond: [
                         {
                             $and: [
-                                { $ne: ["$unit", null] },
+                                { $ne: [{ $type: "$unit" }, "null"] },
+                                { $ne: [{ $type: "$unit" }, "missing"] },
                                 { $ne: ["$unit", ""] }
                             ]
                         },


### PR DESCRIPTION
- Change  comparison to use  operator
- Explicitly check for 'null' and 'missing' types
- Prevents null unit values from being counted as having units
- Fixes harmonized_name_biosample_counts showing 100% coverage for all fields

Closes #271
Related to #268, #237