### PR TITLE
Add ENVO integration history doc for ADR-0015

### DIFF
--- a/docs/env-triad-envo-integration-history.md
+++ b/docs/env-triad-envo-integration-history.md
@@ -71,7 +71,7 @@ The existing 12 value sets were created using one-off Jupyter notebooks with var
 
 1. **Request ENVO deprecate NMDC subset annotation properties**
 
-   Request deprecation of `ENVO:03605010` (NMDC environmental context subsets) and all its subproperties, as NMDC will no longer maintain them.
+   Request deprecation of `ENVO:03605010` (NMDC environmental context subsets) and all its sub-properties, as NMDC will no longer maintain them.
 
 2. **Archive ROBOT template generation code**
 


### PR DESCRIPTION
## Summary

Adds historical context and implementation details moved from the shortened ADR-0015 in microbiomedata/issues.

**Companion to**: microbiomedata/issues#1532

## Contents

The new `docs/env-triad-envo-integration-history.md` includes:
- ENVO subset integration attempt details (Aug 2024 - Aug 2025)
- Why ENVO integration was abandoned (technical fragility, architectural limitations, release coupling)
- Cherry-picking principle history
- Enumeration naming patterns
- Action items (completed and proposed)
- Full related issues list

## Why This Split

ADR-0015 was 218 lines—the longest ADR in the issues repo (median is ~35 lines). This refactoring:
- Keeps the ADR focused on the decision itself
- Moves implementation details and historical context here where they belong alongside the lifecycle documentation

🤖 Generated with [Claude Code](https://claude.ai/code)