### PR TITLE
Add voting sheet inventory and IAA details to lifecycle doc

### DIFF
--- a/docs/environmental-triad-value-set-lifecycle.md
+++ b/docs/environmental-triad-value-set-lifecycle.md
@@ -433,7 +433,7 @@ Terms are included if: `vote_sum >= 1`
 
 ### 3.5 Inter-Annotator Agreement (IAA)
 
-**Current recommendation**: Skip IAA. Per CJM, just use `vote_sum >= 1` for filtering.
+**Current recommendation**: Skip IAA. Per CJM (Chris Mungall), just use `vote_sum >= 1` for filtering.
 
 If IAA is needed (e.g., for analyzing voter agreement patterns), the formula is:
 
@@ -452,7 +452,7 @@ Example with 5 voters (10 pairs = C(5,2)):
 
 ### 3.6 Google Sheets Voting Workbook Inventory
 
-The canonical sheet IDs are those referenced in the submission-schema `post_google_sheets_*.ipynb` notebooks. Many additional copies exist in Google Drive from earlier voting rounds — those are historical and not actively used.
+The canonical sheet IDs are those referenced in the [microbiomedata/submission-schema](https://github.com/microbiomedata/submission-schema) repository's `post_google_sheets_*.ipynb` notebooks. Many additional copies exist in Google Drive from earlier voting rounds — those are historical and not actively used.
 
 #### Canonical Sheets (referenced in submission-schema notebooks)
 
@@ -473,7 +473,7 @@ The canonical sheet IDs are those referenced in the submission-schema `post_goog
 
 To open any sheet: `https://docs.google.com/spreadsheets/d/{Sheet ID}`
 
-#### Sheets Not Yet in Submission-Schema
+#### Sheets Not Yet Referenced in Submission-Schema Notebooks
 
 | Environment | Slot | Sheet ID | Notes |
 |-------------|------|----------|-------|


### PR DESCRIPTION
## Summary
- Adds canonical Google Sheets voting workbook inventory to the lifecycle doc, verified against the actual `SPREADSHEET_ID` values in submission-schema `post_google_sheets_*.ipynb` notebooks
- Adds IAA (inter-annotator agreement) score calculation details: formula, examples, single-voter guidance, and note that `iaa.py` doesn't exist yet
- Notes which environments use procedural ENVO generation (soil broad scale, soil medium) vs. voting sheets

Closes #293

## Context
This information was previously only in the `agscrap` repo (a cross-system scratchpad). The agscrap inventory had many stale/duplicate sheet IDs from old voting rounds. This PR uses the submission-schema notebooks as the source of truth for canonical IDs.

## Test plan
- [ ] Verify sheet IDs open correctly via `https://docs.google.com/spreadsheets/d/{ID}`
- [ ] Review IAA formula description for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)