### PR TITLE
Replace stale Current Work section with link to issue tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,7 @@ poetry run mongo-connect --uri mongodb://localhost:27017/ncbi_metadata --connect
 
 ## Current Work
 
-- **#222**: Biosample normalization
-- **#223**: Infrastructure improvements
+See the [issue tracker](https://github.com/microbiomedata/external-metadata-awareness/issues) for current priorities.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces hard-coded issue references (#222, #223) in CLAUDE.md's "Current Work" section with a link to the live issue tracker
- Prevents this section from going stale as priorities change

## Test plan

- [ ] Verify the markdown link renders correctly on GitHub
- [ ] Confirm no other content in CLAUDE.md was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)