### PR TITLE
Remove final credential-status log for CodeQL

### DIFF
--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -139,7 +139,7 @@ def main():
             # Show minimal connection info without duplicating the output from get_mongo_client
             if not args.verbose:
                 logger.debug("Connection URI prepared")
-            logger.debug(f"Using credentials: {result['has_credentials']}")
+            logger.debug("Credential presence determined")
 
             logger.debug("Sample mongosh command omitted from logs for security")
         else:


### PR DESCRIPTION
## Summary
- remove the final credential-status debug log from mongodb_connection.py
- keep the CLI behavior unchanged while avoiding value-bearing logging
- clear the last remaining CodeQL clear-text logging alert on main

## Testing
- python3 -m py_compile external_metadata_awareness/mongodb_connection.py