### PR TITLE
Add content_pairs_aggregated + harden bioproject pipeline

### DIFF
--- a/Makefiles/measurement_discovery.Makefile
+++ b/Makefiles/measurement_discovery.Makefile
@@ -8,9 +8,10 @@ endif
 
 .PHONY: count-biosamples-step1 count-bioprojects-step2 \
 count-bioprojects-step2a count-bioprojects-step2b count-bioprojects-step2c count-bioprojects-step2d \
+ensure-sra-biosample-accession-index \
 merge-counts-step3 index-harmonized-name-counts count-biosamples-and-bioprojects-per-harmonized-name \
 count-unit-assertions count-mixed-content count-measurement-evidence run-measurement-discovery \
-create-dimensional-stats clean-discovery
+create-dimensional-stats aggregate-content-pairs clean-discovery
 
 # Phase 0: Baseline counting
 
@@ -112,8 +113,21 @@ count-bioprojects-step2d:
 		--verbose
 	@date
 
+# Ensure the biosample_accession index on sra_biosamples_bioprojects that
+# count-bioprojects-step2c pre-flight requires. Creating this is fast (~few
+# minutes on 35M+ rows) and idempotent. Closes #402.
+ensure-sra-biosample-accession-index:
+	@echo "Ensuring biosample_accession index on sra_biosamples_bioprojects..."
+	@date
+	$(RUN) mongo-js-executor \
+		--mongo-uri "$(MONGO_URI)" \
+		$(ENV_FILE_OPTION) \
+		--js-file mongo-js/create_sra_biosamples_bioprojects_index.js \
+		--verbose
+	@date
+
 # Meta-target: Run all Step 2 sub-steps in sequence
-count-bioprojects-step2: count-bioprojects-step2a count-bioprojects-step2b count-bioprojects-step2c count-bioprojects-step2d
+count-bioprojects-step2: ensure-sra-biosample-accession-index count-bioprojects-step2a count-bioprojects-step2b count-bioprojects-step2c count-bioprojects-step2d
 	@echo "✅ Bioproject counting complete (atomic steps)"
 
 # Step 3: Merge biosample and bioproject counts
@@ -166,6 +180,21 @@ count-mixed-content:
 count-measurement-evidence: count-unit-assertions count-mixed-content
 	@echo "✅ Measurement evidence counting complete"
 	@echo "📊 Created collections: unit_assertion_counts, mixed_content_counts"
+
+# Build content_pairs_aggregated: distinct (harmonized_name, content) pairs with biosample counts.
+# Matches K-BERDL's nmdc_ncbi_biosamples.content_pairs_aggregated. Closes #405.
+# Standalone pure-aggregation path — no NER, no API calls. (run-measurement-discovery
+# also produces this collection via --save-aggregation, but bundled with a 4-8 hour
+# quantulum3 NER run; this target is for parity loads where NER is not needed.)
+aggregate-content-pairs:
+	@date
+	@echo "Aggregating (harmonized_name, content) pairs..."
+	$(RUN) mongo-js-executor \
+		--mongo-uri "$(MONGO_URI)" \
+		$(ENV_FILE_OPTION) \
+		--js-file mongo-js/aggregate_content_pairs.js \
+		--verbose
+	@date
 
 # Run quantulum3 measurement discovery (creates measurement_results_skip_filtered + content_pairs_aggregated)
 # FULL PRODUCTION RUN: Processes all 64M (harmonized_name, content) pairs

--- a/mongo-js/aggregate_content_pairs.js
+++ b/mongo-js/aggregate_content_pairs.js
@@ -1,0 +1,76 @@
+// Aggregate distinct (harmonized_name, content) pairs with biosample counts
+// Input: biosamples_attributes → Output: content_pairs_aggregated
+// Mirrors the K-BERDL nmdc_ncbi_biosamples.content_pairs_aggregated table.
+// Closes #405
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Aggregating (harmonized_name, content) pairs`);
+
+// Check if already done
+const existingCount = db.content_pairs_aggregated.estimatedDocumentCount();
+if (existingCount > 0) {
+    print(`[${new Date().toISOString()}] ✓ content_pairs_aggregated has ${existingCount} records`);
+    print(`[${new Date().toISOString()}] Skipping - drop content_pairs_aggregated to rerun`);
+    quit(0);
+}
+
+// Verify source collection has data
+const srcCount = db.biosamples_attributes.estimatedDocumentCount();
+if (srcCount === 0) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: biosamples_attributes is empty`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] biosamples_attributes has ${srcCount.toLocaleString()} records`);
+
+// Drop and rebuild
+db.content_pairs_aggregated.drop();
+
+// Two-stage group: first dedupe (h, c, a), then count distinct accessions per (h, c).
+// Same pattern as count_biosamples_usage_stats_step1.js — avoids $addToSet memory limit.
+print(`[${new Date().toISOString()}] Running aggregation (may take 30-90 min for 800M+ records)...`);
+db.biosamples_attributes.aggregate([
+    {
+        $match: {
+            harmonized_name: {$exists: true, $ne: "", $ne: null},
+            content: {$exists: true, $ne: "", $ne: null},
+            accession: {$exists: true, $ne: "", $ne: null}
+        }
+    },
+    // First $group: deduplicate (harmonized_name, content, accession) triples
+    {
+        $group: {
+            _id: {h: "$harmonized_name", c: "$content", a: "$accession"}
+        }
+    },
+    // Second $group: count unique accessions per (harmonized_name, content)
+    {
+        $group: {
+            _id: {h: "$_id.h", c: "$_id.c"},
+            biosample_count: {$sum: 1}
+        }
+    },
+    {
+        $project: {
+            harmonized_name: "$_id.h",
+            content: "$_id.c",
+            biosample_count: 1,
+            _id: 0
+        }
+    },
+    {
+        $out: "content_pairs_aggregated"
+    }
+], {allowDiskUse: true});
+
+const aggEnd = new Date();
+const resultCount = db.content_pairs_aggregated.countDocuments();
+print(`[${aggEnd.toISOString()}] Aggregation complete: ${resultCount.toLocaleString()} (harmonized_name, content) pairs`);
+
+// Indexes
+print(`[${new Date().toISOString()}] Creating indexes on content_pairs_aggregated...`);
+db.content_pairs_aggregated.createIndex({harmonized_name: 1}, {background: true});
+db.content_pairs_aggregated.createIndex({biosample_count: -1}, {background: true});
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+print(`[${endTime.toISOString()}] ✅ Complete in ${elapsed}s (${(elapsed/60).toFixed(1)} minutes)`);

--- a/mongo-js/create_sra_biosamples_bioprojects_index.js
+++ b/mongo-js/create_sra_biosamples_bioprojects_index.js
@@ -1,0 +1,33 @@
+// Ensure biosample_accession index on sra_biosamples_bioprojects.
+// Required by count_bioprojects_step2c_sra_join.js pre-flight check.
+// Closes #402 — previously no make target created this index, so the
+// composite count-biosamples-and-bioprojects-per-harmonized-name target
+// would bail at step 2c after ~70 min of upstream work.
+
+const startTime = new Date();
+print(`[${startTime.toISOString()}] Ensuring biosample_accession index on sra_biosamples_bioprojects`);
+
+const srcCount = db.sra_biosamples_bioprojects.estimatedDocumentCount();
+if (srcCount === 0) {
+    print(`[${new Date().toISOString()}] ❌ ERROR: sra_biosamples_bioprojects is empty`);
+    print(`[${new Date().toISOString()}] Load SRA pairs first (see sra_metadata.Makefile)`);
+    quit(1);
+}
+print(`[${new Date().toISOString()}] sra_biosamples_bioprojects has ${srcCount.toLocaleString()} records`);
+
+const existing = db.sra_biosamples_bioprojects.getIndexes()
+    .find(idx => idx.key.biosample_accession === 1);
+if (existing) {
+    print(`[${new Date().toISOString()}] ✓ Index already exists: ${existing.name}`);
+    quit(0);
+}
+
+print(`[${new Date().toISOString()}] Creating idx_biosample_accession (a few minutes on 35M+ rows)...`);
+db.sra_biosamples_bioprojects.createIndex(
+    {biosample_accession: 1},
+    {name: "idx_biosample_accession"}
+);
+
+const endTime = new Date();
+const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+print(`[${endTime.toISOString()}] ✅ Index created in ${elapsed}s`);

--- a/mongo-js/merge_usage_stats_step3.js
+++ b/mongo-js/merge_usage_stats_step3.js
@@ -2,6 +2,26 @@
 // Input: temp_biosample_counts + temp_bioproject_counts → Output: harmonized_name_usage_stats
 // Part of harmonized_name usage stats workflow
 
+// Pre-flight: refuse to merge if either input is empty.
+// Closes #404 — previously merge would silently $ifNull to 0 for every bioproject_count
+// when temp_bioproject_counts was empty (e.g., step 2c interrupted by mongosh
+// PoolClearedOnNetworkError while server-side aggregation kept running).
+const tbsCount = db.temp_biosample_counts.estimatedDocumentCount();
+if (tbsCount === 0) {
+    print('[' + new Date().toISOString() + '] ❌ ERROR: temp_biosample_counts is empty');
+    print('[' + new Date().toISOString() + '] Step 1 (count-biosamples-step1) may not have completed');
+    print('[' + new Date().toISOString() + '] Refusing to merge — would produce empty output');
+    quit(1);
+}
+const tbpCount = db.temp_bioproject_counts.estimatedDocumentCount();
+if (tbpCount === 0) {
+    print('[' + new Date().toISOString() + '] ❌ ERROR: temp_bioproject_counts is empty');
+    print('[' + new Date().toISOString() + '] Step 2c (count-bioprojects-step2c) may not have completed');
+    print('[' + new Date().toISOString() + '] Refusing to merge — would produce all-zero unique_bioprojects_count');
+    quit(1);
+}
+print('[' + new Date().toISOString() + '] Pre-flight passed: temp_biosample_counts=' + tbsCount + ', temp_bioproject_counts=' + tbpCount);
+
 print('[' + new Date().toISOString() + '] Ensuring indexes exist before merge');
 db.temp_bioproject_counts.createIndex({harmonized_name: 1}, {background: true});
 db.temp_biosample_counts.createIndex({harmonized_name: 1}, {background: true});


### PR DESCRIPTION
## Why

Today's K-BERDL ↔ M5 parity audit and a failed-and-recovered pipeline run surfaced one missing analytics collection and two related infrastructure bugs:

- `nmdc_ncbi_biosamples.content_pairs_aggregated` (66M rows in K-BERDL) has no producer in this repo. It's the only K-BERDL no-NER analytics table with no M5 equivalent. The functionality exists today only as a side effect of `run-measurement-discovery --save-aggregation`, bundled with a 4-8 hour quantulum3 NER run. This adds a standalone aggregation path. (#405)
- `count-biosamples-and-bioprojects-per-harmonized-name` bails at step 2c after ~70 min of upstream work because no target creates the `sra_biosamples_bioprojects.biosample_accession` index step 2c pre-flights for. Bit M5 today; required manual `db.createIndex(...)` + resume. (#402)
- `merge_usage_stats_step3.js` silently writes all-zero `unique_bioprojects_count` values when `temp_bioproject_counts` is empty (e.g., when mongosh's `PoolClearedOnNetworkError` interrupts step 2c's client connection while the server keeps running). Bit M5 today; cross-checked against K-BERDL Feb 8 and NUC Oct 2025 snapshots to confirm the zeros were corruption, not real data. (#404)

## Closes

- #402
- #404
- #405

## Test plan

- [x] `make -n aggregate-content-pairs` — Makefile syntax + recipe expansion
- [x] `make -n count-biosamples-and-bioprojects-per-harmonized-name` — confirmed `ensure-sra-biosample-accession-index` is now in the composite dependency chain
- [x] `make ensure-sra-biosample-accession-index` against authed M5 Mongo — idempotent (detects existing index, exits 0)
- [ ] Full `make aggregate-content-pairs` on M5 — deferred to post-merge; the new script follows the proven two-stage `$group` pattern from `count_biosamples_usage_stats_step1.js`, but a real run will produce the wall-clock baseline for the K-BERDL parity claim
- [ ] Verify defensive check in `merge_usage_stats_step3.js` triggers correctly when either temp is empty (could be added as a future unit test)

## Not in this PR

- `#403` (mongodb_connection.py doesn't append `?authSource`) — touches the shared auth helper used by every script; broader-impact change deserves its own PR for review focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)