### PR TITLE
Parametrize DOWNLOADS_DIR/LOCAL_DIR; bulk-write xml_to_mongo

### DIFF
--- a/Makefiles/env_triads.Makefile
+++ b/Makefiles/env_triads.Makefile
@@ -1,3 +1,8 @@
+# Configurable storage roots. Override per invocation, e.g.
+#   make TARGET LOCAL_DIR=/Volumes/owc-nvme/local DOWNLOADS_DIR=/Volumes/owc-nvme/downloads
+DOWNLOADS_DIR ?= downloads
+LOCAL_DIR ?= local
+
 RUN = poetry run
 MONGO_URI ?= mongodb://localhost:27017/ncbi_metadata
 
@@ -74,7 +79,6 @@ count-harmonizable-attribs: mongo-js/count_harmonizable_biosample_attribs.js
 		--js-file $< \
 		--verbose # 30? minutes
 	@date
-
 
 env-triads: biosamples-flattened env-triad-value-counts
 
@@ -270,6 +274,4 @@ env-triads-flattened: env-triads-flatten-index
 	@echo "📋 Created collection: env_triads_flattened"
 	@echo "📋 Structure: accession | attribute | instance | raw_original | raw_component | id | label | prefix | source"
 	@echo "📋 Indexes: accession, attribute+instance, id, prefix, accession+attribute+instance"
-
-
 

--- a/Makefiles/ncbi_metadata.Makefile
+++ b/Makefiles/ncbi_metadata.Makefile
@@ -121,7 +121,7 @@ $(DOWNLOADS_DIR)/bioproject.xml:
 load_acceptable_sized_leaf_bioprojects_into_mongodb: $(DOWNLOADS_DIR)/bioproject.xml
 	# Ensure necessary directories exist
 	@mkdir -p $(LOCAL_DIR)/oversize-bioprojects
-	@mkdir -p downloads
+	@mkdir -p $(DOWNLOADS_DIR)
 
 	@date
 	@echo "Using MONGO_URI=$(MONGO_URI)"

--- a/Makefiles/ncbi_metadata.Makefile
+++ b/Makefiles/ncbi_metadata.Makefile
@@ -1,3 +1,8 @@
+# Configurable storage roots. Override per invocation, e.g.
+#   make TARGET LOCAL_DIR=/Volumes/owc-nvme/local DOWNLOADS_DIR=/Volumes/owc-nvme/downloads
+DOWNLOADS_DIR ?= downloads
+LOCAL_DIR ?= local
+
 RUN=poetry run
 WGET=wget
 
@@ -26,30 +31,29 @@ WGET=wget
         copy-environmental-candidates-to-ncbi-metadata
 
 purge:
-	rm -rf downloads/biosample_set.xml*
-	rm -rf local/biosample-count-mongodb.txt
-	rm -rf local/biosample-last-id-line.txt
-	rm -rf local/biosample-last-id-val.txt
-	rm -rf local/biosample_set.xml*
-	rm -rf local/oversize-bioprojects/*
+	rm -rf $(DOWNLOADS_DIR)/biosample_set.xml*
+	rm -rf $(LOCAL_DIR)/biosample-count-mongodb.txt
+	rm -rf $(LOCAL_DIR)/biosample-last-id-line.txt
+	rm -rf $(LOCAL_DIR)/biosample-last-id-val.txt
+	rm -rf $(LOCAL_DIR)/biosample_set.xml*
+	rm -rf $(LOCAL_DIR)/oversize-bioprojects/*
 
-downloads/biosample_set.xml.gz:
+$(DOWNLOADS_DIR)/biosample_set.xml.gz:
 	date
 	$(WGET) -O $@ "https://ftp.ncbi.nlm.nih.gov/biosample/biosample_set.xml.gz" # ~ 3 GB August 2024
 	date
 
 # wget 2 minutes on MAM Ubuntu NUC
 
-local/biosample_set.xml: downloads/biosample_set.xml.gz
+$(LOCAL_DIR)/biosample_set.xml: $(DOWNLOADS_DIR)/biosample_set.xml.gz
 	date
 	gunzip -c $< > $@
 	date
 
 # unzip 9 minutes on MAM Ubuntu NUC
 
-
 # Default file for last ID
-LAST_BIOSAMPLE_ID_FILE := local/biosample-last-id-val.txt
+LAST_BIOSAMPLE_ID_FILE := $(LOCAL_DIR)/biosample-last-id-val.txt
 MONGO_URI ?= mongodb://localhost:27017/ncbi_metadata
 
 # Optional environment file (user must set ENV_FILE externally if they want it)
@@ -58,15 +62,15 @@ ifdef ENV_FILE
 endif
 
 # These rules generate the ID file, if possible
-local/biosample-last-id-line.txt: local/biosample_set.xml
+$(LOCAL_DIR)/biosample-last-id-line.txt: $(LOCAL_DIR)/biosample_set.xml
 	@echo "Building $@"
 	tac $< | grep -m 1 '<BioSample' > $@
 
-local/biosample-last-id-val.txt: local/biosample-last-id-line.txt
+$(LOCAL_DIR)/biosample-last-id-val.txt: $(LOCAL_DIR)/biosample-last-id-line.txt
 	@echo "Building $@"
 	sed -n 's/.*id="\([0-9]*\)".*/\1/p' $< > $@
 
-load-biosamples-into-mongo: local/biosample_set.xml
+load-biosamples-into-mongo: $(LOCAL_DIR)/biosample_set.xml
 	@date
 	$(eval LAST_BIOSAMPLE_ID_VAL := $(if $(LAST_BIOSAMPLE_ID),$(LAST_BIOSAMPLE_ID),$(shell cat $(LAST_BIOSAMPLE_ID_FILE) 2>/dev/null)))
 	@if [ -z "$(LAST_BIOSAMPLE_ID_VAL)" ]; then \
@@ -89,7 +93,6 @@ load-biosamples-into-mongo: local/biosample_set.xml
 	  --anticipated-last-id $(LAST_BIOSAMPLE_ID_VAL)
 	@date
 
-
 # sample usages:
 # make load-biosamples-into-mongo MAX_ELEMENTS=100000
 # make load-biosamples-into-mongo \
@@ -99,7 +102,7 @@ load-biosamples-into-mongo: local/biosample_set.xml
 
 # status update frequency is currently hardcoded with "if processed_count % 10000 == 0"
 
-local/biosample_xpath_counts.json: local/biosample_set.xml
+$(LOCAL_DIR)/biosample_xpath_counts.json: $(LOCAL_DIR)/biosample_set.xml
 	#  --stop-after 999999999
 	# --interval is a number of seconds between updates
 	poetry run count-xml-paths \
@@ -110,21 +113,21 @@ local/biosample_xpath_counts.json: local/biosample_set.xml
 
 ####
 
-downloads/bioproject.xml:
+$(DOWNLOADS_DIR)/bioproject.xml:
 	date
 	$(WGET) -O $@ "https://ftp.ncbi.nlm.nih.gov/bioproject/bioproject.xml" # ~ 3 GB March 2025
 	date
 
-load_acceptable_sized_leaf_bioprojects_into_mongodb: downloads/bioproject.xml
+load_acceptable_sized_leaf_bioprojects_into_mongodb: $(DOWNLOADS_DIR)/bioproject.xml
 	# Ensure necessary directories exist
-	@mkdir -p local/oversize-bioprojects
+	@mkdir -p $(LOCAL_DIR)/oversize-bioprojects
 	@mkdir -p downloads
 
 	@date
 	@echo "Using MONGO_URI=$(MONGO_URI)"
 	$(RUN) load-bioprojects-into-mongodb \
        --clear-collections \
-       --oversize-dir local/oversize-bioprojects \
+       --oversize-dir $(LOCAL_DIR)/oversize-bioprojects \
        --project-collection bioprojects \
        --submission-collection bioprojects_submissions \
        --mongo-uri "$(MONGO_URI)" \
@@ -132,7 +135,7 @@ load_acceptable_sized_leaf_bioprojects_into_mongodb: downloads/bioproject.xml
        --xml-file $< \
        $(ENV_FILE_OPTION)
 
-local/bioproject_xpath_counts.json: downloads/bioproject.xml
+$(LOCAL_DIR)/bioproject_xpath_counts.json: $(DOWNLOADS_DIR)/bioproject.xml
 	# --stop-after 999999999
 	poetry run count-xml-paths \
 		--always-count-path '/PackageSet/Package/Project' \
@@ -212,7 +215,7 @@ copy-environmental-candidates-to-ncbi-metadata:
 
 # Analyze collection structure complexity (flatness scoring)
 # Output: TSV with flatness scores (0-100), useful for identifying export-ready collections
-local/collection_flatness.tsv:
+$(LOCAL_DIR)/collection_flatness.tsv:
 	@date
 	@echo "Analyzing MongoDB collection flatness..."
 	@echo "Using MONGO_URI=$(MONGO_URI)"

--- a/Makefiles/ncbi_schema.Makefile
+++ b/Makefiles/ncbi_schema.Makefile
@@ -1,12 +1,17 @@
+# Configurable storage roots. Override per invocation, e.g.
+#   make TARGET LOCAL_DIR=/Volumes/owc-nvme/local DOWNLOADS_DIR=/Volumes/owc-nvme/downloads
+DOWNLOADS_DIR ?= downloads
+LOCAL_DIR ?= local
+
 RUN=poetry run
 WGET=wget
 
 # todo wget or curl?
 
-downloads/ncbi-biosample-attributes.xml:
+$(DOWNLOADS_DIR)/ncbi-biosample-attributes.xml:
 	$(WGET) -O $@ "https://www.ncbi.nlm.nih.gov/biosample/docs/attributes/?format=xml"
 
-downloads/ncbi-biosample-packages.xml:
+$(DOWNLOADS_DIR)/ncbi-biosample-packages.xml:
 	$(WGET) -O $@ "https://www.ncbi.nlm.nih.gov/biosample/docs/packages/?format=xml"
 
 .PHONY: load-packages-into-mongo load-attributes-into-mongo
@@ -18,7 +23,7 @@ ifdef ENV_FILE
   ENV_FILE_OPTION := --env-file $(ENV_FILE)
 endif
 
-load-packages-into-mongo: downloads/ncbi-biosample-packages.xml
+load-packages-into-mongo: $(DOWNLOADS_DIR)/ncbi-biosample-packages.xml
 	date
 	$(RUN) xml-to-mongo \
 		--anticipated-last-id 250 \
@@ -29,8 +34,7 @@ load-packages-into-mongo: downloads/ncbi-biosample-packages.xml
 		--node-type Package
 	date
 
-
-load-attributes-into-mongo: downloads/ncbi-biosample-attributes.xml
+load-attributes-into-mongo: $(DOWNLOADS_DIR)/ncbi-biosample-attributes.xml
 	date
 	$(RUN) xml-to-mongo \
 		--anticipated-last-id 1000 \
@@ -42,7 +46,7 @@ load-attributes-into-mongo: downloads/ncbi-biosample-attributes.xml
 	date
 
 # Extract comprehensive package fields to TSV
-local/ncbi_packages_fields.tsv: downloads/ncbi-biosample-packages.xml
+$(LOCAL_DIR)/ncbi_packages_fields.tsv: $(DOWNLOADS_DIR)/ncbi-biosample-packages.xml
 	@date
 	@echo "Extracting comprehensive NCBI package fields to TSV..."
 	@mkdir -p local

--- a/Makefiles/ncbi_schema.Makefile
+++ b/Makefiles/ncbi_schema.Makefile
@@ -49,7 +49,7 @@ load-attributes-into-mongo: $(DOWNLOADS_DIR)/ncbi-biosample-attributes.xml
 $(LOCAL_DIR)/ncbi_packages_fields.tsv: $(DOWNLOADS_DIR)/ncbi-biosample-packages.xml
 	@date
 	@echo "Extracting comprehensive NCBI package fields to TSV..."
-	@mkdir -p local
+	@mkdir -p $(LOCAL_DIR)
 	$(RUN) extract-ncbi-packages-fields \
 		--xml-file $< \
 		--output-file $@

--- a/Makefiles/ncbi_to_duckdb.Makefile
+++ b/Makefiles/ncbi_to_duckdb.Makefile
@@ -1,3 +1,8 @@
+# Configurable storage roots. Override per invocation, e.g.
+#   make TARGET LOCAL_DIR=/Volumes/owc-nvme/local DOWNLOADS_DIR=/Volumes/owc-nvme/downloads
+DOWNLOADS_DIR ?= downloads
+LOCAL_DIR ?= local
+
 # NCBI MongoDB to DuckDB Migration Makefile
 # Dumps 100% flat collections from ncbi_metadata MongoDB to DuckDB
 
@@ -187,26 +192,26 @@ export-satisfying-biosamples:
 	fi
 	@echo "Exporting satisfying biosamples to CSV..."
 	@echo "Query: sql/satisfying_biosamples.sql"
-	@duckdb "$(DUCKDB_FILE)" < sql/satisfying_biosamples.sql -csv > local/satisfying_biosamples.csv
-	@echo "✓ Exported to: local/satisfying_biosamples.csv"
-	@wc -l local/satisfying_biosamples.csv | awk '{printf "  %s biosamples (including header)\n", $$1}'
-	@ls -lh local/satisfying_biosamples.csv | awk '{printf "  File size: %s\n", $$5}'
+	@duckdb "$(DUCKDB_FILE)" < sql/satisfying_biosamples.sql -csv > $(LOCAL_DIR)/satisfying_biosamples.csv
+	@echo "✓ Exported to: $(LOCAL_DIR)/satisfying_biosamples.csv"
+	@wc -l $(LOCAL_DIR)/satisfying_biosamples.csv | awk '{printf "  %s biosamples (including header)\n", $$1}'
+	@ls -lh $(LOCAL_DIR)/satisfying_biosamples.csv | awk '{printf "  File size: %s\n", $$5}'
 
 # Normalize satisfying biosamples (dates to YYYY-MM-DD, coordinates to separate lat/lon columns)
 normalize-satisfying-biosamples:
-	@if [ ! -f "local/satisfying_biosamples.csv" ]; then \
-		echo "Error: local/satisfying_biosamples.csv not found"; \
+	@if [ ! -f "$(LOCAL_DIR)/satisfying_biosamples.csv" ]; then \
+		echo "Error: $(LOCAL_DIR)/satisfying_biosamples.csv not found"; \
 		echo "Run 'make -f Makefiles/ncbi_to_duckdb.Makefile export-satisfying-biosamples' first"; \
 		exit 1; \
 	fi
 	@echo "Normalizing biosample dates and coordinates..."
 	@poetry run normalize-satisfying-biosamples \
-		--input-file local/satisfying_biosamples.csv \
-		--output-file local/satisfying_biosamples_normalized.csv
+		--input-file $(LOCAL_DIR)/satisfying_biosamples.csv \
+		--output-file $(LOCAL_DIR)/satisfying_biosamples_normalized.csv
 	@echo ""
-	@echo "✓ Normalized file created: local/satisfying_biosamples_normalized.csv"
-	@wc -l local/satisfying_biosamples_normalized.csv | awk '{printf "  %s biosamples (including header)\\n", $$1}'
-	@ls -lh local/satisfying_biosamples_normalized.csv | awk '{printf "  File size: %s\\n", $$5}'
+	@echo "✓ Normalized file created: $(LOCAL_DIR)/satisfying_biosamples_normalized.csv"
+	@wc -l $(LOCAL_DIR)/satisfying_biosamples_normalized.csv | awk '{printf "  %s biosamples (including header)\\n", $$1}'
+	@ls -lh $(LOCAL_DIR)/satisfying_biosamples_normalized.csv | awk '{printf "  File size: %s\\n", $$5}'
 
 # Show summary of tables in DuckDB
 show-summary:

--- a/Makefiles/sra_metadata.Makefile
+++ b/Makefiles/sra_metadata.Makefile
@@ -1,3 +1,8 @@
+# Configurable storage roots. Override per invocation, e.g.
+#   make TARGET LOCAL_DIR=/Volumes/owc-nvme/local DOWNLOADS_DIR=/Volumes/owc-nvme/downloads
+DOWNLOADS_DIR ?= downloads
+LOCAL_DIR ?= local
+
 RUN=poetry run
 
 # Default MongoDB connection
@@ -26,15 +31,15 @@ SRA_BIGQUERY_LIMIT = 30000000 # expect ~ 30000000
 # Target: purge-sra
 # Removes all SRA data files and temporary directories
 purge-sra:
-	rm -rf downloads/sra_accession_pairs.tsv
-	rm -rf downloads/sra_metadata_table_schema.tsv
-	rm -rf local/sra_metadata_parquet
+	rm -rf $(DOWNLOADS_DIR)/sra_accession_pairs.tsv
+	rm -rf $(DOWNLOADS_DIR)/sra_metadata_table_schema.tsv
+	rm -rf $(LOCAL_DIR)/sra_metadata_parquet
 
 # Target: dump-sra-metadata-schema
 # Dumps the BigQuery SRA metadata table schema to a TSV file
-dump-sra-metadata-schema: downloads/sra_metadata_table_schema.tsv
+dump-sra-metadata-schema: $(DOWNLOADS_DIR)/sra_metadata_table_schema.tsv
 
-downloads/sra_metadata_table_schema.tsv:
+$(DOWNLOADS_DIR)/sra_metadata_table_schema.tsv:
 	@echo "Dumping SRA metadata schema from BigQuery..."
 	$(RUN) dump-sra-metadata-schema \
 		--project $(SRA_BIGQUERY_PROJECT) \
@@ -57,7 +62,7 @@ biosample-bioproject-preview:
 
 # Target: sra_accession_pairs_tsv_to_mongo
 # Exports BioSample-BioProject pairs from SRA to MongoDB
-downloads/sra_accession_pairs.tsv:
+$(DOWNLOADS_DIR)/sra_accession_pairs.tsv:
 	@echo "Exporting ALL SRA accession pairs to TSV (no limit)..."
 	$(RUN) export-sra-accession-pairs \
 		--project $(SRA_BIGQUERY_PROJECT) \
@@ -68,7 +73,7 @@ downloads/sra_accession_pairs.tsv:
 		--output $@ \
 		--verbose
 
-sra_accession_pairs_tsv_to_mongo: downloads/sra_accession_pairs.tsv
+sra_accession_pairs_tsv_to_mongo: $(DOWNLOADS_DIR)/sra_accession_pairs.tsv
 	@echo "Loading SRA accession pairs into MongoDB..."
 	@echo "Using MONGO_URI=$(MONGO_URI)"
 	$(RUN) sra-accession-pairs-to-mongo \
@@ -81,15 +86,15 @@ sra_accession_pairs_tsv_to_mongo: downloads/sra_accession_pairs.tsv
 
 # Target: fetch_sra_metadata_parquet_from_s3
 # Fetches SRA metadata Parquet files from S3
-local/sra_metadata_parquet:
+$(LOCAL_DIR)/sra_metadata_parquet:
 	mkdir -p $@
 
 # Default setup (set a flag for Perlmutter or local execution)
 USE_SHIFTER ?= 0  # Default to local (0 means not using shifter)
 
-fetch_sra_metadata_parquet_from_s3: local/sra_metadata_parquet
+fetch_sra_metadata_parquet_from_s3: $(LOCAL_DIR)/sra_metadata_parquet
 	# Ensure necessary directories exist
-	@mkdir -p local/sra_metadata_parquet
+	@mkdir -p $(LOCAL_DIR)/sra_metadata_parquet
 
 	@date
 	@if [ "$(USE_SHIFTER)" -eq 1 ]; then \
@@ -112,7 +117,7 @@ ifdef SRA_PARQUET_MAX_ROWS
   SRA_PARQUET_ROWS_OPTION := --nrows $(SRA_PARQUET_MAX_ROWS)
 endif
 
-load-sra-parquet-to-mongo: local/sra_metadata_parquet
+load-sra-parquet-to-mongo: $(LOCAL_DIR)/sra_metadata_parquet
 	@date
 	@echo "Using MONGO_URI=$(MONGO_URI)"
 	$(RUN) sra-parquet-to-mongodb \
@@ -151,14 +156,14 @@ count_sra_metadata_keys:
 		--js-file mongo-js/count_sra_metadata_keys.js \
 		--verbose && date
 
-local/sra_biosample_bioproject_pairs.tsv: sql/extract_sra_biosample_bioproject_pairs_to_tsv.sql local/sra_metadata_parquet
+$(LOCAL_DIR)/sra_biosample_bioproject_pairs.tsv: sql/extract_sra_biosample_bioproject_pairs_to_tsv.sql $(LOCAL_DIR)/sra_metadata_parquet
 	@echo "Extracting biosample-bioproject pairs from SRA parquet files using DuckDB..."
-	duckdb local/sra.duckdb < $<
+	duckdb $(LOCAL_DIR)/sra.duckdb < $<
 	@echo "Exported biosample-bioproject pairs to $@"
 
 # Target: load-sra-pairs-to-mongo
 # Loads the TSV file into MongoDB collection with proper field names
-load-sra-pairs-to-mongo: local/sra_biosample_bioproject_pairs.tsv
+load-sra-pairs-to-mongo: $(LOCAL_DIR)/sra_biosample_bioproject_pairs.tsv
 	@echo "Loading SRA biosample-bioproject pairs into MongoDB..."
 	$(RUN) sra-accession-pairs-to-mongo \
 		--file-path $< \

--- a/external_metadata_awareness/xml_to_mongo.py
+++ b/external_metadata_awareness/xml_to_mongo.py
@@ -20,11 +20,14 @@ from external_metadata_awareness.mongodb_connection import get_mongo_client
               help='Anticipated last ID for progress calculation.')
 @click.option('--mongo-uri', required=True, help='MongoDB connection URI (must start with mongodb:// and include database name).')
 @click.option('--env-file', default=None, help='Path to .env file for credentials (should contain MONGO_USER and MONGO_PASSWORD).')
+@click.option('--batch-size', default=1000, type=int,
+              help='Documents per bulk insert (default 1000). Larger batches trade memory for throughput.')
 @click.option('--verbose', is_flag=True, help='Show verbose connection output.')
 def load_xml_to_mongodb(file_path: str, collection_name: str, node_type: str,
                         id_field: str, max_elements: Optional[int] = None,
                         anticipated_last_id: Optional[int] = None, mongo_uri: str = None,
-                        env_file: Optional[str] = None, verbose: bool = False):
+                        env_file: Optional[str] = None, batch_size: int = 1000,
+                        verbose: bool = False):
     """
     Loads data from an XML file into MongoDB, preserving the nested structure.
 
@@ -71,12 +74,20 @@ def load_xml_to_mongodb(file_path: str, collection_name: str, node_type: str,
 
         start_time = time.time()
         processed_count = 0
+        batch = []
+
+        def flush(batch):
+            if batch:
+                collection.insert_many(batch, ordered=False)
+                batch.clear()
 
         for event, elem in ET.iterparse(file_path, events=('end',)):
             if elem.tag == node_type:
-                doc = element_to_dict(elem)
-                collection.insert_one(doc)
+                batch.append(element_to_dict(elem))
                 processed_count += 1
+
+                if len(batch) >= batch_size:
+                    flush(batch)
 
                 # Show progress based on max_elements if provided, otherwise use anticipated_last_id
                 if processed_count % 10000 == 0:
@@ -86,7 +97,7 @@ def load_xml_to_mongodb(file_path: str, collection_name: str, node_type: str,
                         progress = (int(elem.attrib.get(id_field, 0)) / anticipated_last_id) * 100
                     else:
                         progress = 0
-                        
+
                     elapsed_time = time.time() - start_time
                     print(f"Processed {processed_count} {node_type} nodes ({progress:.2f}%), "
                           f"elapsed time: {elapsed_time:.2f} seconds")
@@ -96,6 +107,8 @@ def load_xml_to_mongodb(file_path: str, collection_name: str, node_type: str,
                     break
 
                 elem.clear()
+
+        flush(batch)
 
     except Exception as e:
         print(f"An error occurred: {e}")


### PR DESCRIPTION
Two independent quality-of-life changes, bundled.

## #391 — Configurable storage roots

Five Makefiles (`env_triads`, `ncbi_metadata`, `ncbi_schema`, `ncbi_to_duckdb`, `sra_metadata`) now expose:

```make
DOWNLOADS_DIR ?= downloads
LOCAL_DIR ?= local
```

Every `downloads/<path>` and `local/<path>` reference in those files is now `\$(DOWNLOADS_DIR)/<path>` / `\$(LOCAL_DIR)/<path>`. Defaults match prior behavior — every existing invocation works unchanged. Users on multi-disk setups can now redirect the bulk paths:

```bash
make load-biosamples-into-mongo \
  ENV_FILE=local/.env \
  LOCAL_DIR=/Volumes/owc-nvme/external-metadata-awareness/local \
  DOWNLOADS_DIR=/Volumes/owc-nvme/external-metadata-awareness/downloads
```

Notes on the rewrite:

- The variable definitions sit at the **very top** of each Makefile because target names using `\$(VAR)` are expanded at parse time — defining the var later than the rule yields an empty target name. Caught this with a dry-run override.
- `local/.env*` references inside example-invocation **comments** were preserved literally (a copy-paste CLI arg should be `ENV_FILE=local/.env`, not `ENV_FILE=\$(LOCAL_DIR)/.env`).
- `ENV_FILE` itself is a separate Makefile variable users pass in independently — it's not coupled to `LOCAL_DIR`. So credentials stay anchored to the repo as the issue called for.

Out of scope (could be follow-ups under the same banner): `gold.Makefile`, `mixs.Makefile`, `nmdc_metadata.Makefile`, `nmdc_schema.Makefile`, `github.Makefile`, `test_workflow.Makefile`. The issue listed 6 affected Makefiles; this PR covers 5 of them. (Sixth, `measurement_discovery.Makefile`, has no `downloads/`/`local/` references.)

## #389 — Bulk-write xml_to_mongo

`xml-to-mongo` now batches `insert_many(batch, ordered=False)` instead of `insert_one(doc)` per element. New `--batch-size` flag (default 1000). Final partial batch flushed after the loop; `--max-elements` early-exit preserved.

Throughput on a small slice (20K BioSample docs against the local M5):
- Old code (issue body): ~7,700 docs/sec
- This branch: ~14,000 docs/sec (1.43s for 20K)

Roughly 2x on a small slice; the issue projected 3-5x at full scale, which I haven't benchmarked but is consistent with how batched writes scale.

Also tested partial-final-batch (3777 docs landed exactly).

## Test plan

- [x] `make -nf Makefiles/ncbi_metadata.Makefile LOCAL_DIR=... DOWNLOADS_DIR=... .../biosample-last-id-val.txt` routes every prereq to overridden paths
- [x] Default invocation still resolves `local/biosample-last-id-val.txt` to the existing file
- [x] `poetry run xml-to-mongo --max-elements {3777,5000,20000}` lands exactly that count in MongoDB
- [ ] (Not run) Full 56M-doc load against the production biosamples collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)