### PR TITLE
Rename coverage_percent → biosample_coverage_percent; add tqdm; drop dead entry point

### DIFF
--- a/docs/MONGODB_PATTERNS.md
+++ b/docs/MONGODB_PATTERNS.md
@@ -325,7 +325,7 @@ When renaming a field in an existing collection, do **all three** in the same PR
      {$rename: {old_name: "new_name"}}
    )
    ```
-   `$rename` is metadata-cheap (no index rebuild if the field isn't indexed; one index drop+create if it is). 810-doc renames complete in milliseconds.
+   **Cost:** `$rename` is *not* metadata-only. MongoDB rewrites every matched document (the field is stored under its new key in each BSON record) and the `{old_name: {$exists: true}}` filter is a full collection scan when the field isn't indexed. For a small collection like `harmonized_name_biosample_counts` (810 docs) this completes in milliseconds; for a 56M-doc collection like `biosamples_flattened` it would be a multi-minute operation comparable to the original `$merge` that wrote the collection. Check `db.<collection>.estimatedDocumentCount()` first and schedule accordingly.
 3. **Update consumers** — grep the repo for the old name (`grep -rn '<old_name>'`) and update Python scripts, JS aggregations, notebooks, and docs that reference it. Watch for false positives where the old name is a substring (e.g., `coverage_percent` vs. `unit_coverage_percent`).
 
 **Verify after step 2:**

--- a/docs/MONGODB_PATTERNS.md
+++ b/docs/MONGODB_PATTERNS.md
@@ -310,3 +310,28 @@ This allows the same scripts to run against different database instances without
 3. **Missing indexes after `$out`**: `$out` replaces the target with a new collection that has no indexes. Always recreate indexes after.
 4. **`$addToSet` memory**: Collecting millions of unique values into a set per group exceeds the 100MB limit. Use multi-step deduplication instead.
 5. **Assuming `estimatedDocumentCount` is exact**: It uses collection metadata and can be stale after bulk operations. Use `countDocuments({})` when precision matters.
+
+---
+
+## Field-Rename-in-Place Protocol
+
+When renaming a field in an existing collection, do **all three** in the same PR so the new name is applied both to the data and to the code that produces it. No after-the-fact backfill scripts to remember.
+
+1. **Edit the producer** — change the field name in the aggregation script (`mongo-js/...`) that writes the collection. Update any index recipe lines that name the field.
+2. **Rename in place** on the existing collection:
+   ```javascript
+   db.<collection>.updateMany(
+     {old_name: {$exists: true}},
+     {$rename: {old_name: "new_name"}}
+   )
+   ```
+   `$rename` is metadata-cheap (no index rebuild if the field isn't indexed; one index drop+create if it is). 810-doc renames complete in milliseconds.
+3. **Update consumers** — grep the repo for the old name (`grep -rn '<old_name>'`) and update Python scripts, JS aggregations, notebooks, and docs that reference it. Watch for false positives where the old name is a substring (e.g., `coverage_percent` vs. `unit_coverage_percent`).
+
+**Verify after step 2:**
+```javascript
+db.<collection>.countDocuments({old_name: {$exists: true}})  // expect 0
+db.<collection>.findOne().new_name                            // expect the original value
+```
+
+If the renamed field has an index, drop the old-name index after the rename and create a new-name index in the same step; otherwise reruns of the producer (which `$out` replaces the collection) will fail to find the named index.

--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -13,6 +13,7 @@ import requests_cache
 from dotenv import load_dotenv
 from prefixmaps.io.parser import load_converter
 from pymongo import uri_parser
+from tqdm import tqdm
 
 from external_metadata_awareness.mongodb_connection import get_mongo_client
 
@@ -244,11 +245,12 @@ def main(mongo_uri, env_file, collection, verbose):
     # Get all documents matching the query
     docs_cursor = collection.find(query)
     doc_count = collection.count_documents(query)
-    
+
     print(f"Found {doc_count} documents to process")
 
-    # Process each document
-    for doc in docs_cursor:
+    # Process each document. Each call may make multiple BioPortal API requests,
+    # so wrap the iteration in tqdm for a visible progress bar.
+    for doc in tqdm(docs_cursor, total=doc_count, desc="BioPortal mapping", unit="doc"):
         process_document(doc, collection, BIOPORTAL_API_KEY, verbose)
 
     print("Processing complete.")

--- a/mongo-js/count_biosamples_flattened_field_usage.js
+++ b/mongo-js/count_biosamples_flattened_field_usage.js
@@ -43,7 +43,7 @@ db.biosamples_flattened.aggregate([
             harmonized_name: "$_id",
             biosample_count: 1,
             unique_accessions: { $size: "$sample_accessions" },
-            coverage_percent: {
+            biosample_coverage_percent: {
                 $round: [{
                     $multiply: [
                         { $divide: ["$biosample_count", totalBiosamples] },

--- a/mongo-js/count_biosamples_per_hn_step3.js
+++ b/mongo-js/count_biosamples_per_hn_step3.js
@@ -63,7 +63,7 @@ db.getCollection("__tmp_hn_counts").aggregate([
             total_attribute_records: "$t.total_attribute_records",
             has_unit_records: "$t.has_unit_records",
             unit_coverage_percent: "$t.unit_coverage_percent",
-            coverage_percent: {
+            biosample_coverage_percent: {
                 $cond: [
                     { $gt: [totalUniqueAccessions, 0] },
                     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ random-sample-resources = 'external_metadata_awareness.adhoc.random_sample_resou
 xml-to-mongo = 'external_metadata_awareness.xml_to_mongo:load_xml_to_mongodb'
 
 # New aliases for Makefile scripts
-add-duckdb-key-value-row = 'external_metadata_awareness.add_duckdb_key_value_row:main'
 analyze-collection-flatness = 'external_metadata_awareness.analyze_collection_flatness:main'
 dump-sra-metadata-schema = 'external_metadata_awareness.dump_sra_metadata_table_schema:main'
 env-triad-values-splitter = 'external_metadata_awareness.new_env_triad_values_splitter:main'


### PR DESCRIPTION
Three small fixes plus a new doc section. Closes #274, #159, and (as obsolete) #41.

## #274 — Rename `coverage_percent` → `biosample_coverage_percent`

The `harmonized_name_biosample_counts` collection has two coverage fields that meant different things:
- `coverage_percent` — fraction of biosamples that have this harmonized_name (the renamed one)
- `unit_coverage_percent` — fraction of attribute records that include a unit (kept as-is)

Renamed both in code (`count_biosamples_per_hn_step3.js`) **and** in the live collection in the same PR — no after-the-fact backfill required. A single `$rename` `updateMany` matched/modified all 810 docs in milliseconds (no index rebuild — the field wasn't indexed).

**Verified live:**
- `geo_loc_name.biosample_coverage_percent = 61.78` (same value as the pre-rename `coverage_percent`)
- Zero remaining docs with the old field name

Also renamed in the sibling aggregation `count_biosamples_flattened_field_usage.js`, which writes the same ambiguity into `biosamples_flattened_field_counts` (not currently built on M5, so no DB-side rename needed there).

## #159 — Add tqdm to BioPortal mapper

`new_bioportal_curie_mapper.py` made N BioPortal API calls per document with no progress visibility. Wrapped the per-document loop in `tqdm(...)` with the precomputed `count_documents` total.

## #41 — Now obsolete

The script the issue references (`add_duckdb_key_value_row.py`) was deleted in April 2025 (commit `a56505d`, env_triads refactoring). The `add-duckdb-key-value-row` entry point in `pyproject.toml` was a dangling reference to the deleted module. Removed.

## Doc: field-rename-in-place protocol

Added a section to `docs/MONGODB_PATTERNS.md` describing the pattern this PR exercises:

> 1. Edit the producer JS.
> 2. \`\$rename\` in place on the live collection.
> 3. Update consumers (grep for false positives like `unit_coverage_percent` vs. `coverage_percent`).
>
> All three in the same PR — no separate backfill scripts to remember.

## Test plan

- [x] `db.harmonized_name_biosample_counts.countDocuments({coverage_percent: {\$exists: true}})` returns 0
- [x] `db.harmonized_name_biosample_counts.findOne({harmonized_name: "geo_loc_name"}).biosample_coverage_percent` equals 61.78
- [x] No remaining `coverage_percent` references in non-archived JS or Python (the one in `analyze_nmdc_biosample_coverage.py` is for a different, unrelated dict-output key)
- [ ] (Not run) `new_bioportal_curie_mapper` against the real collection — tqdm shows the per-doc bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)