### PR TITLE
Remove environmental-candidates-2017-plus filter; document collection export rationale and satellite-project history

### DIFF
--- a/Makefiles/ncbi_metadata.Makefile
+++ b/Makefiles/ncbi_metadata.Makefile
@@ -28,9 +28,7 @@ WGET=wget
         flatten_biosample_attributes \
         flatten_biosample_packages \
         biosamples-flattened \
-        aggregate-biosample-package-usage \
-        create-environmental-candidates-2017-plus \
-        copy-environmental-candidates-to-ncbi-metadata
+        aggregate-biosample-package-usage
 
 purge:
 	rm -rf $(DOWNLOADS_DIR)/biosample_set.xml*
@@ -223,28 +221,6 @@ aggregate-biosample-package-usage: biosamples-flattened
 		$(ENV_FILE_OPTION) \
 		--js-file mongo-js/aggregate_biosample_package_usage.js \
 		--verbose
-	@date
-
-create-environmental-candidates-2017-plus:
-	@date
-	@echo "Creating environmental candidates collection (2017+, complete triads)..."
-	$(RUN) mongo-connect \
-		--uri "$(MONGO_URI)" \
-		$(ENV_FILE_OPTION) \
-		--connect \
-		--verbose \
-		--command 'db.biosamples.aggregate([{$$match: {"Attributes.Attribute": {$$all: [{$$elemMatch: {harmonized_name: "collection_date", content: {$$gte: "2017-01-01"}}}, {$$elemMatch: {harmonized_name: "env_broad_scale", content: {$$exists: true, $$ne: null, $$ne: ""}}}, {$$elemMatch: {harmonized_name: "env_local_scale", content: {$$exists: true, $$ne: null, $$ne: ""}}}, {$$elemMatch: {harmonized_name: "env_medium", content: {$$exists: true, $$ne: null, $$ne: ""}}}]}}}, {$$out: "environmental_candidates_2017_plus"}])'
-	@date
-
-copy-environmental-candidates-to-ncbi-metadata:
-	@date
-	@echo "Copying environmental candidates to ncbi_metadata.biosamples..."
-	$(RUN) mongo-connect \
-		--uri "$(MONGO_URI)" \
-		$(ENV_FILE_OPTION) \
-		--connect \
-		--verbose \
-		--command 'db.environmental_candidates_2017_plus.aggregate([{$$out: {db: "$(shell echo $(MONGO_URI) | sed 's|.*/||')", coll: "biosamples"}}])'
 	@date
 
 # Analyze collection structure complexity (flatness scoring)

--- a/docs/collection-export-rationale.md
+++ b/docs/collection-export-rationale.md
@@ -1,0 +1,143 @@
+# Collection export rationale
+
+For each MongoDB collection EMA can export to the DuckDB/Parquet lakehouse target, this doc names a consumer, a canonical query that consumer would actually run, and the reason the collection is worth shipping. Source of truth for the current export list: `Makefiles/ncbi_to_duckdb.Makefile :: FLAT_COLLECTIONS`.
+
+The intent is to make the export decision *justifiable per collection*, not inherited from prior choices. If a collection here has no concrete consumer + query + reason, it shouldn't be in `FLAT_COLLECTIONS`.
+
+Status legend:
+- **export**: currently in `FLAT_COLLECTIONS`; justification below
+- **candidate**: not currently exported; reviewing
+- **internal**: keep loaded in Mongo, do not export
+
+## Currently exported
+
+### attribute_harmonized_pairings — export
+
+- Consumer: schema-mapping analysts (you, NMDC submission-portal devs)
+- Query: "For attribute `geographic location`, which `harmonized_name` values are actually used in NCBI? What's the count distribution?"
+- Reason: lets a downstream tool map raw NCBI attribute strings to canonical harmonized_names without re-aggregating 800M rows.
+
+### bioprojects_flattened — export
+
+- Consumer: NMDC lakehouse, JGI Dremio cross-source joins
+- Query: "Join biosamples to their parent BioProject on `project_accession`; filter by submission date range."
+- Reason: the only flat representation of BioProject metadata. Cross-source joins need it.
+
+### biosamples_attributes — export
+
+- Consumer: NMDC K-BERDL parity ingest, measurement analysts, value-set curators
+- Query: "Distinct values of `content` for `harmonized_name = 'env_medium'`, ranked by frequency."
+- Reason: the long-format attribute table is the substrate everything else aggregates from. 812M rows; consumers need it pre-flattened, not re-derived.
+
+### biosamples_flattened — export
+
+- Consumer: NMDC lakehouse, biosample-level analysts
+- Query: "Filter biosamples by collection_date / lat_lon / env_broad_scale; export the resulting accession list."
+- Reason: one row per biosample with the most-queried fields surfaced (env triad, dates, location). Without it, every consumer redoes the same flatten.
+
+### biosamples_ids — export
+
+- Consumer: cross-source id-resolution (NMDC ↔ NCBI ↔ submitter aliases)
+- Query: "Given submitter sample name X, find the NCBI accession."
+- Reason: the only flat crosswalk of NCBI accession to alternate identifiers.
+
+### biosamples_links — export
+
+- Consumer: cross-source ID linkage (publication-to-sample, accession-to-URL)
+- Query: "All biosamples linked to PMID 12345" / "All biosamples with a SRA run link."
+- Reason: linking table for any external-resource enrichment.
+
+### content_pairs_aggregated — export
+
+- Consumer: NMDC K-BERDL parity (#405), measurement curation, value-set design
+- Query: "All distinct `content` values for `harmonized_name = 'depth'` with biosample counts."
+- Reason: deduplicates 712M rows to ~64M unique pairs. K-BERDL parity gap (#405) is the immediate driver; downstream curation needs the dedup to be cheap.
+
+### env_triads_flattened — export
+
+- Consumer: env-triad value-set development, NMDC lakehouse env-triad analytics, agentic ingest consumers (Sujay's `nmdc-ingest-agent` may read this for known resolutions; see #426 for a leaner sibling)
+- Query: "All resolved CURIEs for env_medium component label `soil`, with source and ontology."
+- Reason: the resolvable side of the env-triad pipeline; flat shape lets it be joined to biosample queries.
+
+### harmonized_name_dimensional_stats — export
+
+- Consumer: measurement curators, schema designers (you)
+- Query: "What dimensional patterns (length, mass, etc.) does `harmonized_name = 'depth'` exhibit across NCBI?"
+- Reason: small summary table; used for picking what to model in measurement work and for catching dimensional drift.
+
+### harmonized_name_usage_stats — export
+
+- Consumer: anyone deciding what to prioritize for harmonization, modeling, or curation
+- Query: "Top 100 harmonized_names by unique_biosamples_count" / "Is this rare attribute used in any project?"
+- Reason: the prevalence signal for every harmonized_name across both biosamples and bioprojects.
+
+### measurement_evidence_percentages — export
+
+- Consumer: measurement curators, slot prioritization
+- Query: "Which harmonized_names have ≥X% unit-bearing values and ≥Y% mixed-content (numeric+text) prevalence?"
+- Reason: the precomputed ratios that drive measurement-target selection.
+
+### measurement_results_skip_filtered — export
+
+- Consumer: measurement consumers (NMDC lakehouse, dimensional analysis)
+- Query: "All parsed measurements for `depth` with their value, unit, and original_content."
+- Reason: this is the value-add of the 4-8 hour quantulum3 pass. Currently has the "crazy units" problem (#363); export keeps the raw and parsed both so downstream can re-canonicalize.
+
+### mixed_content_counts — export
+
+- Consumer: measurement curators
+- Query: "Which harmonized_names most frequently have alphanumeric content (likely value+unit)?"
+- Reason: one of the signals feeding `measurement_evidence_percentages`. Cheap to keep around for ad-hoc analysis.
+
+### ncbi_attributes_flattened — export
+
+- Consumer: anyone interpreting harmonized_name semantics
+- Query: "What is the NCBI-stated definition and synonym list for `harmonized_name = 'geo_loc_name'`?"
+- Reason: the canonical NCBI attribute dictionary, flat. Reference data for downstream tools.
+
+### ncbi_packages_flattened — export
+
+- Consumer: voting-sheet workflow, NMDC submission-portal schema designers
+- Query: "Which attributes are required by the `MIMS.me.soil` package?"
+- Reason: package-to-attribute crosswalk; required for any "what should this submission contain?" question.
+
+### sra_biosamples_bioprojects — export
+
+- Consumer: NMDC lakehouse, JGI Dremio, anyone joining sequencing data to sample metadata
+- Query: "Given BioSample accession X, list all SRA runs and their parent BioProjects."
+- Reason: the cross-DB derive (PR #400) is the join key for sequencing-aware analytics.
+
+### unit_assertion_counts — export
+
+- Consumer: measurement curators, UCUM mapping work (#363)
+- Query: "For `harmonized_name = 'depth'`, what unit strings have been asserted and how often?"
+- Reason: the unit-frequency signal used both for picking measurement targets and for building UCUM mappings.
+
+## Candidates not currently exported
+
+### harmonized_name_biosample_counts — candidate
+
+- Consumer: same as `measurement_evidence_percentages`, but at a finer grain
+- Query: "Which harmonized_names have ≥X% `unit_coverage_percent` AND high `biosample_count`?"
+- Reason to add: distinct fields from `harmonized_name_usage_stats` (carries the unit-coverage signal, which usage_stats does not). #274 (closed 2026-05-19) addressed the naming ambiguity. **Decision: probably export; collapses one consumer query that today needs to scan attributes.**
+
+### global_mixs_slots, global_nmdc_slots — internal
+
+- Consumer: dimensional validation, hybrid measurement-target selection (issue: TBD), measurement-record processing
+- Query: "What's the range type and preferred units for MIxS slot `depth`?"
+- Reason **not** to export: the upstream YAML is the source of truth and consumers should fetch from there; EMA uses these collections at processing time, but downstream consumers of the lakehouse shouldn't need them.
+- Decision: keep loaded, don't export.
+
+### bioprojects_submissions — internal
+
+- Consumer: none currently
+- Query: none
+- Reason **not** to export: orphaned since load. Carries submission envelope (submitter, status, date). Keep loaded with minimal indexing per the in-conversation decision; revisit if a freshness-diff use case (#367) needs it.
+- Decision: keep loaded, do not export.
+
+## Open questions to resolve
+
+1. **What gets `harmonized_name_biosample_counts` into FLAT_COLLECTIONS, and what gets the rename from #274 propagated through?** Both are blocked on #388 (naming umbrella).
+2. **Is there a real external consumer for `sra_biosamples_bioprojects` in BERDL today, or is it speculative?** The cross-DB derive is recent (PR #400); we should verify consumer.
+3. **For each "NMDC lakehouse" consumer claim above, which collections does BERDL actually ingest today vs aspirationally?** This doc is honest where we know; speculative where we don't. Verifying with the BERDL ingest config would tighten the rationale.
+4. **Should `env_triads_flattened` keep its current shape or be reshaped per #426 (the deterministic CURIE lookup table for agent consumers)?** Different consumer profile.

--- a/docs/satellite-embedding-project-history.md
+++ b/docs/satellite-embedding-project-history.md
@@ -1,0 +1,51 @@
+# Satellite-embedding project — history and current status
+
+This doc exists so future readers can understand why this repo once contained an aggressive `biosamples`-filter pipeline (`create-environmental-candidates-2017-plus` and `copy-environmental-candidates-to-ncbi-metadata`) and what became of the work those targets supported. Both targets were removed on 2026-05-19 because the project they served is no longer active here.
+
+## What the project was
+
+The plan was to join two embedding spaces over the same physical location:
+
+1. **Google AlphaEarth Satellite Embedding V1** — Google Earth Engine's pre-trained satellite imagery embeddings, sampled per year per geographic tile. Coverage starts in **2017**.
+2. **Biosample ENVO triad embeddings** — text embeddings (or other vector representations) of NCBI BioSample `env_broad_scale`, `env_local_scale`, `env_medium` values, joined to `lat_lon` from the same biosample record.
+
+If both vectors describe the same site, you should be able to learn a mapping that lets you predict an ENVO triad annotation from satellite imagery, or conversely flag suspicious biosamples whose annotated environment doesn't match what the satellite says is there.
+
+Two pieces of the work lived in two repos:
+
+- **EMA (this repo)**: produced the metadata-side substrate — a 3M-biosample DuckDB containing biosamples with complete env triads and `collection_date >= 2017-01-01`. The 2017 cutoff existed solely to align with AlphaEarth's temporal coverage. The filter targets here (`create-environmental-candidates-2017-plus` → `copy-environmental-candidates-to-ncbi-metadata`) materialized that subset *destructively* into the `biosamples` collection.
+- **`contextualizer-ai/env-embeddings`** (separate repo, on the LBL Intel MBP): held the satellite-embedding side and the modeling code (~41 GB of CSV/TSV files).
+
+The shared metadata DuckDB was published to NERSC at `https://portal.nersc.gov/project/m3408/biosamples_duckdb/`.
+
+## What became of it
+
+Status: **paused / archived**, with the data side effectively gone.
+
+- The LBL Intel MBP migration deprecated the local copy of `contextualizer-ai/env-embeddings` and the ~41 GB of satellite-embedding source data. None of it was backed up to the NUC. The repo presumably still exists on GitHub but is not actively wired into anything in EMA's current pipelines.
+- The metadata-side DuckDB snapshot (`ncbi_metadata_3M_biosamples_flat_20250930.duckdb`, 2.2 GiB) was deleted from the NUC's OWC enclosure on 2026-05-15 as part of the broader embedding-and-snapshot cleanup. Verified to contain only the standard EMA analytics tables filtered to the 3M subset — no embeddings.
+- The deletion record is documented at `~/Desktop/markdown/owc-embeddings-deletion-2026-05-15/DELETION-RECORD-2026-05-15.md` (follow-up #4). That file is the canonical record of what was deleted and the rationale.
+- The architecture design doc lives at `~/from-intel/Desktop/Desktop/markdown/satellite-ontology-embedding-architecture.md` on the Intel-MBP migration staging tree. Not in this repo; not on Desktop; not backed up.
+- The NERSC portal at `https://portal.nersc.gov/project/m3408/biosamples_duckdb/` still hosts the 3M-row DuckDB and Parquet exports (project `m3408` is NMDC's NERSC project). Reachable, but stale — predates Feb 2026's pipeline rebuild.
+
+## Why we removed the filter targets
+
+Two reasons:
+
+1. **The project they served is no longer active**, so running the targets just to "complete the pipeline" produces a destructively pruned `biosamples` collection for no current purpose.
+2. **The replacement is in flight**: the Feb 2026 pipeline rebuild and the in-progress refactor (issue #424) target a full 51.7M-biosample workflow, not a 3M-row subset. Keeping the 2017-plus filter around invites accidental reactivation that would silently shrink the working dataset.
+
+The targets were removed in the same commit that introduced this doc.
+
+## If someone wants to revive the work
+
+- The satellite-embedding side: check whether `contextualizer-ai/env-embeddings` on GitHub still has the modeling code; the raw embeddings may need to be re-derived from Google Earth Engine.
+- The metadata side: rebuild the filter inline if needed. The `$match` aggregation that the removed `create-environmental-candidates-2017-plus` target used is preserved in git history (search `git log --all -p Makefiles/ncbi_metadata.Makefile`).
+- Open a new issue scoping the join's current relevance before re-introducing any of this; it's been ~6 months idle and the surrounding ecosystem has moved.
+
+## Cross-refs
+
+- `~/Desktop/markdown/owc-embeddings-deletion-2026-05-15/DELETION-RECORD-2026-05-15.md` — deletion record, especially follow-up #4
+- `docs/pipeline-rebuild-pain-points.md` — NERSC portal reference and the 3M→51.7M rebuild context
+- `docs/data-products-inventory.md` — historical inventory of DuckDB tables
+- `unorganized/September-2025-Biosample-DuckDB-documentation.html` — per-table schema for the 3M subset, from when the project was active


### PR DESCRIPTION
## Why

Three related cleanups from the 2026-05-18/19 collection audit:

1. **Remove `create-environmental-candidates-2017-plus` and `copy-environmental-candidates-to-ncbi-metadata`** from `Makefiles/ncbi_metadata.Makefile`. These existed to filter the `biosamples` collection down to a triad-complete, post-2017 subset that aligned with Google AlphaEarth Satellite Embedding V1's temporal coverage. The satellite-side data lived only on the LBL Intel MBP (`contextualizer-ai/env-embeddings`, ~41 GB) and is no longer accessible after migration; the metadata-side DuckDB snapshot was deleted from the NUC on 2026-05-15. The filter is destructive — it `$out`s the filtered subset back into the `biosamples` collection — so leaving it around invites accidental data shrinkage. No other code references these targets or the resulting collection.

2. **Add `docs/satellite-embedding-project-history.md`** so a future maintainer can understand what those targets were for, what became of the project they served, where the surviving documentation lives, and what to do if anyone wants to revive the work.

3. **Add `docs/collection-export-rationale.md`** capturing, for every collection currently in `Makefiles/ncbi_to_duckdb.Makefile :: FLAT_COLLECTIONS`, a documented consumer, the canonical query that consumer would run, and the reason the collection is worth exporting. Classifies three candidates (`harmonized_name_biosample_counts`, `global_*_slots`, `bioprojects_submissions`) with proposed dispositions, and lists four open questions to resolve via #388 and a BERDL-consumer audit. The intent is that the export decision should be justifiable per collection, not inherited.

## Test plan

- [ ] No make target other than the two removed ones references `environmental_candidates_2017_plus` or the related targets (verified by repo-wide grep at commit time).
- [ ] `make -f Makefiles/ncbi_metadata.Makefile` still parses and lists its targets without errors.
- [ ] Existing `biosamples` collection in your local MongoDB is unaffected by this change — only future runs of the pipeline would have been affected, and now they won't be.
- [ ] The two new docs render correctly in GitHub markdown.

## Follow-ups (not in this PR)

- Update issue #424 to drop the `create-environmental-candidates-2017-plus` bullet from its pipeline list (the issue still references it as a planned pipeline step).
- Resolve the four open questions in `docs/collection-export-rationale.md`.
- Audit other repo docs that still reference these targets historically (`docs/environmental-context-targets-not-covered-2025-09-29.md`); leave as historical artifacts unless they actively mislead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)