### PR TITLE
Move nmdc-submissions per-env config into .env files; unify dev/prod variable names (#437)

### DIFF
--- a/Makefiles/nmdc_metadata.Makefile
+++ b/Makefiles/nmdc_metadata.Makefile
@@ -128,46 +128,29 @@ local/nmdc-consensus-collections.txt: local/nmdc-prod-api-advertised-collections
 local/nmdc-prod-api-advertised-collection-stats.json:
 	curl -sSL 'https://api.microbiomedata.org/nmdcschema/collection_stats' | jq . > $@
 
+# Submissions fetch: the .env file is the canonical per-environment config.
+# It holds NMDC_DATA_SUBMISSION_REFRESH_TOKEN plus MONGO_URI, BASE_URL, and
+# OUTPUT_FILE for that environment. The dev target overrides only which env
+# file to load; everything else lives inside the file.
 NMDC_SUBMISSIONS_ENV ?= local/.env.nmdc-submissions
-NMDC_SUBMISSIONS_TSV ?= $(NMDC_EXPORT_DIR)/flattened_submission_biosamples.tsv
-NMDC_SUBMISSIONS_BASE_URL ?= https://data.microbiomedata.org
 
-# Data-dev environment config
-NMDC_SUBMISSIONS_DEV_ENV ?= local/.env.nmdc-submissions-data-dev
-NMDC_SUBMISSIONS_DEV_TSV ?= $(NMDC_EXPORT_DIR)/flattened_submission_biosamples_data_dev.tsv
-NMDC_DATA_DEV_MONGO_URI ?= mongodb://localhost:27017/nmdc_data_dev
-NMDC_SUBMISSIONS_DEV_BASE_URL ?= https://data-dev.microbiomedata.org
+nmdc-submissions-to-mongo-dev: NMDC_SUBMISSIONS_ENV := local/.env.nmdc-submissions-data-dev
 
-.PHONY: nmdc-submissions-to-mongo
-nmdc-submissions-to-mongo:
+.PHONY: nmdc-submissions-to-mongo nmdc-submissions-to-mongo-dev
+nmdc-submissions-to-mongo nmdc-submissions-to-mongo-dev:
 	@if [ ! -f "$(NMDC_SUBMISSIONS_ENV)" ]; then \
 		echo "Error: $(NMDC_SUBMISSIONS_ENV) not found."; \
-		echo "Create it with: NMDC_DATA_SUBMISSION_REFRESH_TOKEN=<your-token>"; \
+		echo "Create it with at minimum:"; \
+		echo "  NMDC_DATA_SUBMISSION_REFRESH_TOKEN=<token from data[-dev].microbiomedata.org Local Storage>"; \
+		echo "  MONGO_URI=mongodb://<user>:<pw>@<host>:<port>/<db>?authSource=admin"; \
+		echo "  BASE_URL=https://data.microbiomedata.org   (or https://data-dev.microbiomedata.org)"; \
+		echo "  OUTPUT_FILE=$(NMDC_EXPORT_DIR)/flattened_submission_biosamples.tsv"; \
 		exit 1; \
 	fi
 	@mkdir -p $(NMDC_EXPORT_DIR)
 	$(RUN) python external_metadata_awareness/nmdc-submissions-to-mongo.py \
 		run-all \
-		--mongo-url "$(MONGO_URI)" \
-		--env-path "$(NMDC_SUBMISSIONS_ENV)" \
-		--output-file "$(NMDC_SUBMISSIONS_TSV)" \
-		--base-url "$(NMDC_SUBMISSIONS_BASE_URL)"
-
-.PHONY: nmdc-submissions-to-mongo-dev
-nmdc-submissions-to-mongo-dev:
-	@if [ ! -f "$(NMDC_SUBMISSIONS_DEV_ENV)" ]; then \
-		echo "Error: $(NMDC_SUBMISSIONS_DEV_ENV) not found."; \
-		echo "Create it with: NMDC_DATA_SUBMISSION_REFRESH_TOKEN=<your-token>"; \
-		echo "Token source: https://data-dev.microbiomedata.org (Local Storage after ORCID login)"; \
-		exit 1; \
-	fi
-	@mkdir -p $(NMDC_EXPORT_DIR)
-	$(RUN) python external_metadata_awareness/nmdc-submissions-to-mongo.py \
-		run-all \
-		--mongo-url "$(NMDC_DATA_DEV_MONGO_URI)" \
-		--env-path "$(NMDC_SUBMISSIONS_DEV_ENV)" \
-		--output-file "$(NMDC_SUBMISSIONS_DEV_TSV)" \
-		--base-url "$(NMDC_SUBMISSIONS_DEV_BASE_URL)"
+		--env-path "$(NMDC_SUBMISSIONS_ENV)"
 
 NMDC_SUBMISSIONS_DUCKDB ?= local/nmdc_submissions.duckdb
 NMDC_EVAL_INPUT_TARGET_TSV ?= $(NMDC_EXPORT_DIR)/eval_input_target_pairs.tsv
@@ -186,9 +169,19 @@ eval-input-target-tsv: export-submissions-to-duckdb
 
 NMDC_SUBMISSION_COLLECTIONS = nmdc_submissions flattened_submission_biosamples submission_biosample_rows submission_biosample_slot_counts
 
-.PHONY: drop-nmdc-submissions
-drop-nmdc-submissions:
-	@echo "Dropping submission collections from $(MONGO_URI)..."
-	@for coll in $(NMDC_SUBMISSION_COLLECTIONS); do \
-		mongosh "$(MONGO_URI)" --quiet --eval "db.getCollection('$$coll').drop(); print('Dropped: $$coll');" ; \
+# Reads MONGO_URI from $(NMDC_SUBMISSIONS_ENV) so the credentials never appear
+# on the command line or in echoed recipes. Dev target overrides which file is
+# loaded, same as the fetch targets above.
+nmdc-submissions-drop-dev: NMDC_SUBMISSIONS_ENV := local/.env.nmdc-submissions-data-dev
+
+.PHONY: drop-nmdc-submissions nmdc-submissions-drop-dev
+drop-nmdc-submissions nmdc-submissions-drop-dev:
+	@if [ ! -f "$(NMDC_SUBMISSIONS_ENV)" ]; then \
+		echo "Error: $(NMDC_SUBMISSIONS_ENV) not found."; \
+		exit 1; \
+	fi
+	@echo "Dropping submission collections from MongoDB configured by $(NMDC_SUBMISSIONS_ENV) ..."
+	@set -a && . "$(NMDC_SUBMISSIONS_ENV)" && set +a && \
+	for coll in $(NMDC_SUBMISSION_COLLECTIONS); do \
+		mongosh "$$MONGO_URI" --quiet --eval "db.getCollection('$$coll').drop(); print('Dropped: $$coll');" ; \
 	done

--- a/external_metadata_awareness/nmdc-submissions-to-mongo.py
+++ b/external_metadata_awareness/nmdc-submissions-to-mongo.py
@@ -12,6 +12,22 @@ from linkml_runtime import SchemaView
 from oaklib import get_adapter
 
 
+# Per-env config keys read from the .env file when CLI flags aren't supplied.
+# The env file is the canonical per-environment config; CLI flags override.
+ENV_CONFIG_KEYS = ("MONGO_URI", "BASE_URL", "OUTPUT_FILE")
+
+
+def resolve_env_config(env_path, **cli_overrides):
+    """Merge per-env config from `env_path` with CLI overrides.
+
+    CLI overrides win; missing CLI values fall back to the env file; missing
+    env values stay None so callers can apply their own defaults or error out.
+    """
+    env_vars = dotenv_values(env_path) if env_path else {}
+    return {key: cli_overrides.get(key.lower()) or env_vars.get(key)
+            for key in ENV_CONFIG_KEYS}
+
+
 # =============================================================================
 # FETCH NMDC SUBMISSIONS FROM THE API
 # =============================================================================
@@ -533,15 +549,24 @@ def cli():
     pass
 
 
+_ENV_PATH_HELP = ('Path to .env file. Holds NMDC_DATA_SUBMISSION_REFRESH_TOKEN'
+                  ' and per-env config (MONGO_URI, BASE_URL, OUTPUT_FILE).')
+
+
 @cli.command('fetch')
-@click.option('--mongo-url', required=True, help='MongoDB connection URL')
-@click.option('--env-path', default="../../local/.env", help='Path to .env file containing auth tokens')
-@click.option('--base-url', default="https://data.microbiomedata.org",
-              help='Portal base URL (use https://data-dev.microbiomedata.org for dev)')
-def fetch_cmd(mongo_url, env_path, base_url):
+@click.option('--env-path', required=True, help=_ENV_PATH_HELP)
+@click.option('--mongo-url', default=None, help='Overrides MONGO_URI from env file')
+@click.option('--base-url', default=None, help='Overrides BASE_URL from env file')
+def fetch_cmd(env_path, mongo_url, base_url):
     """Fetch NMDC submissions from the API and store in MongoDB."""
-    click.echo(f"Fetching NMDC submissions from {base_url} ...")
-    success = fetch_nmdc_submissions(mongo_url, env_path, base_url)
+    cfg = resolve_env_config(env_path, mongo_uri=mongo_url, base_url=base_url)
+    if not cfg['MONGO_URI']:
+        raise click.UsageError(
+            f"MONGO_URI not in {env_path} and --mongo-url not supplied."
+        )
+    base = cfg['BASE_URL'] or 'https://data.microbiomedata.org'
+    click.echo(f"Fetching NMDC submissions from {base} ...")
+    success = fetch_nmdc_submissions(cfg['MONGO_URI'], env_path, base)
     if success:
         click.echo("Submissions fetched successfully.")
     else:
@@ -598,13 +623,26 @@ def check_compliance_cmd(mongo_url):
 
 
 @cli.command('run-all')
-@click.option('--mongo-url', required=True, help='MongoDB connection URL')
-@click.option('--env-path', default="../../local/.env", help='Path to .env file containing auth tokens')
-@click.option('--output-file', default='flattened_submission_biosamples.tsv', help='Output TSV file path')
-@click.option('--base-url', default="https://data.microbiomedata.org",
-              help='Portal base URL (use https://data-dev.microbiomedata.org for dev)')
-def run_all_cmd(mongo_url, env_path, output_file, base_url):
+@click.option('--env-path', required=True, help=_ENV_PATH_HELP)
+@click.option('--mongo-url', default=None, help='Overrides MONGO_URI from env file')
+@click.option('--output-file', default=None, help='Overrides OUTPUT_FILE from env file')
+@click.option('--base-url', default=None, help='Overrides BASE_URL from env file')
+def run_all_cmd(env_path, mongo_url, output_file, base_url):
     """Run the complete extraction and processing pipeline."""
+    cfg = resolve_env_config(
+        env_path,
+        mongo_uri=mongo_url,
+        base_url=base_url,
+        output_file=output_file,
+    )
+    if not cfg['MONGO_URI']:
+        raise click.UsageError(
+            f"MONGO_URI not in {env_path} and --mongo-url not supplied."
+        )
+    mongo_url = cfg['MONGO_URI']
+    base_url = cfg['BASE_URL'] or 'https://data.microbiomedata.org'
+    output_file = cfg['OUTPUT_FILE'] or 'flattened_submission_biosamples.tsv'
+
     click.echo(f"Running the complete pipeline against {base_url} ...")
 
     click.echo("\n1. Fetching submissions...")


### PR DESCRIPTION
## Summary

- The `.env` file is now the canonical per-environment config for `nmdc-submissions-to-mongo`. Alongside the existing `NMDC_DATA_SUBMISSION_REFRESH_TOKEN`, the file now carries `MONGO_URI`, `BASE_URL`, and `OUTPUT_FILE` for that environment.
- Dev/prod Makefile targets share one recipe shape; the only thing that differs is the env file path. `NMDC_DATA_DEV_MONGO_URI`, `NMDC_SUBMISSIONS_DEV_ENV`, `NMDC_SUBMISSIONS_DEV_TSV`, `NMDC_SUBMISSIONS_DEV_BASE_URL` are removed.
- `drop-nmdc-submissions` (plus new sibling `nmdc-submissions-drop-dev`) reads `MONGO_URI` from the env file in-recipe, so the credentialed URI never reaches `make`'s recipe-echo or the process command line.

## Test plan

- [x] Local dev fetch: 728 submissions ingested, recipe runs silent (no credential string anywhere in stdout)
- [x] Local prod fetch: 733 submissions, 25,465 biosamples flattened, 38,405 biosample rows; pipeline runs to completion
- [x] `drop-nmdc-submissions` and `nmdc-submissions-drop-dev` succeed without echoing `MONGO_URI`

## User-facing change

Existing users with a `local/.env.nmdc-submissions[-data-dev]` file containing only `NMDC_DATA_SUBMISSION_REFRESH_TOKEN` will now also need to add `MONGO_URI=...` (and optionally `BASE_URL` / `OUTPUT_FILE`). The Makefile error message lists the minimum keys when the file is missing; it could be extended to validate keys present in an existing file, but that's a follow-up.

Closes #437.