### PR TITLE
Add gitleaks secret scanning (CI) + nbstripout

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,56 @@
+name: secret-scan
+
+# Scans NEW commits on every PR and push for committed credentials, using
+# gitleaks with the repo's .gitleaks.toml (default rules + a BioPortal/NCBO
+# API-key rule that GitHub's native secret scanning misses because the key is
+# a bare UUID). This gates new leaks; secrets already in history are handled by
+# rotation, not by failing CI forever, so the scan is limited to the new range.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          set -euo pipefail
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan new commits
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            RANGE="$PR_BASE..$PR_HEAD"
+          elif [ -n "$PUSH_BEFORE" ] && [ "$PUSH_BEFORE" != "0000000000000000000000000000000000000000" ]; then
+            RANGE="$PUSH_BEFORE..$PUSH_HEAD"
+          else
+            RANGE=""
+          fi
+          if [ -n "$RANGE" ]; then
+            echo "Scanning commit range: $RANGE"
+            gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --log-opts="$RANGE"
+          else
+            echo "No prior ref; scanning full tree"
+            gitleaks detect --source . --config .gitleaks.toml --redact --no-banner
+          fi

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,9 +18,10 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install gitleaks
         env:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+# Gitleaks configuration for external-metadata-awareness.
+#
+# Extends the built-in ruleset and adds rules for credentials that gitleaks'
+# default rules miss because they are bare UUIDs with no provider prefix. The
+# motivating case: NCBO BioPortal / BioOntology API keys are plain UUIDs
+# (e.g. in a `?apikey=<uuid>` URL or a `BIOPORTAL_API_KEY=<uuid>` assignment).
+# GitHub's native secret scanning and most default rules skip bare UUIDs to
+# avoid false positives, so the only reliable signal is the apikey CONTEXT.
+title = "external-metadata-awareness gitleaks config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "bioportal-ncbo-api-key"
+description = "BioPortal / NCBO BioOntology API key (UUID in an apikey context)"
+regex = '''(?i)(?:bioportal[_-]?(?:api[_-]?key|token)|api[_-]?key|apikey)["'\s:=>]{0,4}(?:token=)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+keywords = ["apikey", "api_key", "bioportal", "bioontology"]
+
+[[rules]]
+id = "bioportal-ncbo-apikey-url"
+description = "BioPortal / NCBO API key embedded in a bioontology.org URL"
+regex = '''bioontology\.org[^\s"'<>]*apikey=[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+keywords = ["bioontology"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com
+#
+# nbstripout removes Jupyter notebook OUTPUT cells before commit. This is
+# prevention for a whole class of leak (any credential, token, or PII that
+# ends up in a rendered cell output), independent of pattern matching. It is
+# here because a BioPortal API key leaked into a notebook output cell in this
+# repo. Detection of committed secrets is handled separately by gitleaks in CI.
+repos:
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.9.1
+    hooks:
+      - id: nbstripout


### PR DESCRIPTION
## Why

A live NCBO BioPortal API key is committed in this repo, in `notebooks/bioportal_mappings_parsing_illustration.ipynb` (a notebook output cell) and `unorganized/bioportal-class-mapping-errors.txt`. GitHub's native secret scanning (enabled here) and gitleaks' default rules do not catch it, because a BioPortal key is a bare UUID with no provider prefix and flagging all UUIDs would be pure noise.

## What

- `.gitleaks.toml`: community default ruleset plus one BioPortal/NCBO rule keyed on the `apikey` context, so it does not flag innocent UUIDs.
- `.github/workflows/secret-scan.yml`: gitleaks on the new commits of each PR/push (commit range, not full history).
- `.pre-commit-config.yaml`: nbstripout, which strips notebook output cells before commit. This is prevention for the actual leak vector here (a secret rendered into a notebook output), and it generalizes to any credential or PII in outputs, not a specific pattern.

## Important

This does not remove the already-committed key. The owner of that key must rotate it; scrubbing it from the working tree and history is a separate follow-up.