### PR TITLE
Address Copilot review on recently merged PRs

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,3 +1,4 @@
+---
 name: secret-scan
 
 # Scans NEW commits on every PR and push for committed credentials, using
@@ -28,7 +29,7 @@ jobs:
           GITLEAKS_VERSION: 8.30.1
         run: |
           set -euo pipefail
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 # See https://pre-commit.com
 #
 # nbstripout removes Jupyter notebook OUTPUT cells before commit. This is

--- a/Makefiles/mixs.Makefile
+++ b/Makefiles/mixs.Makefile
@@ -5,8 +5,10 @@ WGET=wget
 # https://github.com/microbiomedata/external-metadata-awareness/issues/449).
 # Install it separately to run the sex/gender analysis recipe below, e.g.:
 #   uv tool install llm && llm install llm-anthropic
-# Override with LLM=/path/to/llm if it is not on PATH.
-LLM ?= llm
+# Override with LLM_CLI=/path/to/llm if it is not on PATH. The name is
+# specific (not plain LLM) so it cannot be clobbered by a user's exported
+# LLM environment variable, which Make would otherwise import.
+LLM_CLI ?= llm
 
 # preferable to use a tagged release, but theres good stuff in this commit that hasn't been released yet
 MIXS_YAML_URL=https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/b0b1e03b705cb432d08914c686ea820985b9cb20/src/mixs/schema/mixs.yaml
@@ -28,7 +30,7 @@ local/mixs-slots-enums-no-MixsCompliantData-domain.json
 
 local/mixs-slots-sex-gender-analysis-response.txt: local/mixs-slots-sex-gender-analysis-prompt.txt
 	# cborg/claude-opus
-	cat $(word 1,$^) | $(LLM) prompt --model claude-3.5-sonnet -o temperature 0.01 | tee $@
+	cat $(word 1,$^) | $(LLM_CLI) prompt --model claude-3.5-sonnet -o temperature 0.01 | tee $@
 
 # getting fragments of MIxS because the whole thing is too large to feed into an LLM
 local/mixs-extensions-with-slots.json: downloads/mixs.yaml

--- a/Makefiles/nmdc_metadata.Makefile
+++ b/Makefiles/nmdc_metadata.Makefile
@@ -145,7 +145,7 @@ nmdc-submissions-to-mongo nmdc-submissions-to-mongo-dev:
 		echo "  MONGO_URI=mongodb://<user>:<pw>@<host>:<port>/<db>?authSource=admin"; \
 		echo "Optional (the CLI supplies defaults when omitted):"; \
 		echo "  BASE_URL=https://data.microbiomedata.org   (or https://data-dev.microbiomedata.org)"; \
-		echo "  OUTPUT_FILE=local/nmdc-metadata-out/flattened_submission_biosamples.tsv"; \
+		echo "  OUTPUT_FILE=local/nmdc_export/flattened_submission_biosamples.tsv  (under the default NMDC_EXPORT_DIR)"; \
 		exit 1; \
 	fi
 	@mkdir -p $(NMDC_EXPORT_DIR)

--- a/Makefiles/nmdc_metadata.Makefile
+++ b/Makefiles/nmdc_metadata.Makefile
@@ -140,11 +140,12 @@ nmdc-submissions-to-mongo-dev: NMDC_SUBMISSIONS_ENV := local/.env.nmdc-submissio
 nmdc-submissions-to-mongo nmdc-submissions-to-mongo-dev:
 	@if [ ! -f "$(NMDC_SUBMISSIONS_ENV)" ]; then \
 		echo "Error: $(NMDC_SUBMISSIONS_ENV) not found."; \
-		echo "Create it with at minimum:"; \
+		echo "Required:"; \
 		echo "  NMDC_DATA_SUBMISSION_REFRESH_TOKEN=<token from data[-dev].microbiomedata.org Local Storage>"; \
 		echo "  MONGO_URI=mongodb://<user>:<pw>@<host>:<port>/<db>?authSource=admin"; \
+		echo "Optional (the CLI supplies defaults when omitted):"; \
 		echo "  BASE_URL=https://data.microbiomedata.org   (or https://data-dev.microbiomedata.org)"; \
-		echo "  OUTPUT_FILE=$(NMDC_EXPORT_DIR)/flattened_submission_biosamples.tsv"; \
+		echo "  OUTPUT_FILE=local/nmdc-metadata-out/flattened_submission_biosamples.tsv"; \
 		exit 1; \
 	fi
 	@mkdir -p $(NMDC_EXPORT_DIR)
@@ -169,9 +170,12 @@ eval-input-target-tsv: export-submissions-to-duckdb
 
 NMDC_SUBMISSION_COLLECTIONS = nmdc_submissions flattened_submission_biosamples submission_biosample_rows submission_biosample_slot_counts
 
-# Reads MONGO_URI from $(NMDC_SUBMISSIONS_ENV) so the credentials never appear
-# on the command line or in echoed recipes. Dev target overrides which file is
-# loaded, same as the fetch targets above.
+# Reads MONGO_URI from $(NMDC_SUBMISSIONS_ENV) with a non-executing dotenv
+# parser (not shell sourcing, which would mishandle URIs containing '&' and
+# would run any code in the file) and passes it to mongosh through the
+# environment rather than as an argv parameter, so the credential is not
+# visible in process listings or echoed recipes. Dev target overrides which
+# file is loaded, same as the fetch targets above.
 nmdc-submissions-drop-dev: NMDC_SUBMISSIONS_ENV := local/.env.nmdc-submissions-data-dev
 
 .PHONY: drop-nmdc-submissions nmdc-submissions-drop-dev
@@ -181,7 +185,7 @@ drop-nmdc-submissions nmdc-submissions-drop-dev:
 		exit 1; \
 	fi
 	@echo "Dropping submission collections from MongoDB configured by $(NMDC_SUBMISSIONS_ENV) ..."
-	@set -a && . "$(NMDC_SUBMISSIONS_ENV)" && set +a && \
-	for coll in $(NMDC_SUBMISSION_COLLECTIONS); do \
-		mongosh "$$MONGO_URI" --quiet --eval "db.getCollection('$$coll').drop(); print('Dropped: $$coll');" ; \
-	done
+	@MONGO_URI="$$($(RUN) python -c 'from dotenv import dotenv_values; print(dotenv_values("$(NMDC_SUBMISSIONS_ENV)").get("MONGO_URI") or "")')"; \
+	if [ -z "$$MONGO_URI" ]; then echo "Error: MONGO_URI not set in $(NMDC_SUBMISSIONS_ENV)"; exit 1; fi; \
+	MONGO_URI="$$MONGO_URI" NMDC_SUBMISSION_COLLECTIONS="$(NMDC_SUBMISSION_COLLECTIONS)" \
+		mongosh --nodb --quiet --eval 'const db = connect(process.env.MONGO_URI); process.env.NMDC_SUBMISSION_COLLECTIONS.split(/\s+/).forEach(function (c) { db.getCollection(c).drop(); print("Dropped: " + c); });'

--- a/docs/satellite-embedding-project-history.md
+++ b/docs/satellite-embedding-project-history.md
@@ -1,4 +1,4 @@
-# Satellite-embedding project — history and current status
+# Satellite-embedding project: history and current status
 
 This doc exists so future readers can understand why this repo once contained an aggressive `biosamples`-filter pipeline (`create-environmental-candidates-2017-plus` and `copy-environmental-candidates-to-ncbi-metadata`) and what became of the work those targets supported. Both targets were removed on 2026-05-19 because the project they served is no longer active here.
 
@@ -6,15 +6,15 @@ This doc exists so future readers can understand why this repo once contained an
 
 The plan was to join two embedding spaces over the same physical location:
 
-1. **Google AlphaEarth Satellite Embedding V1** — Google Earth Engine's pre-trained satellite imagery embeddings, sampled per year per geographic tile. Coverage starts in **2017**.
-2. **Biosample ENVO triad embeddings** — text embeddings (or other vector representations) of NCBI BioSample `env_broad_scale`, `env_local_scale`, `env_medium` values, joined to `lat_lon` from the same biosample record.
+1. **Google AlphaEarth Satellite Embedding V1**: Google Earth Engine's pre-trained satellite imagery embeddings, sampled per year per geographic tile. Coverage starts in **2017**.
+2. **Biosample ENVO triad embeddings**: text embeddings (or other vector representations) of NCBI BioSample `env_broad_scale`, `env_local_scale`, `env_medium` values, joined to `lat_lon` from the same biosample record.
 
 If both vectors describe the same site, you should be able to learn a mapping that lets you predict an ENVO triad annotation from satellite imagery, or conversely flag suspicious biosamples whose annotated environment doesn't match what the satellite says is there.
 
 Two pieces of the work lived in two repos:
 
-- **EMA (this repo)**: produced the metadata-side substrate — a 3M-biosample DuckDB containing biosamples with complete env triads and `collection_date >= 2017-01-01`. The 2017 cutoff existed solely to align with AlphaEarth's temporal coverage. The filter targets here (`create-environmental-candidates-2017-plus` → `copy-environmental-candidates-to-ncbi-metadata`) materialized that subset *destructively* into the `biosamples` collection.
-- **`contextualizer-ai/env-embeddings`** (separate repo, on the LBL Intel MBP): held the satellite-embedding side and the modeling code (~41 GB of CSV/TSV files).
+- **EMA (this repo)**: produced the metadata-side substrate, a 3M-biosample DuckDB containing biosamples with complete env triads and `collection_date >= 2017-01-01`. The 2017 cutoff existed solely to align with AlphaEarth's temporal coverage. The filter targets here (`create-environmental-candidates-2017-plus`, then `copy-environmental-candidates-to-ncbi-metadata`) materialized that subset *destructively* into the `biosamples` collection.
+- **`contextualizer-ai/env-embeddings`** (separate GitHub repo): held the satellite-embedding side and the modeling code (~41 GB of CSV/TSV files).
 
 The shared metadata DuckDB was published to NERSC at `https://portal.nersc.gov/project/m3408/biosamples_duckdb/`.
 
@@ -22,11 +22,10 @@ The shared metadata DuckDB was published to NERSC at `https://portal.nersc.gov/p
 
 Status: **paused / archived**, with the data side effectively gone.
 
-- The LBL Intel MBP migration deprecated the local copy of `contextualizer-ai/env-embeddings` and the ~41 GB of satellite-embedding source data. None of it was backed up to the NUC. The repo presumably still exists on GitHub but is not actively wired into anything in EMA's current pipelines.
-- The metadata-side DuckDB snapshot (`ncbi_metadata_3M_biosamples_flat_20250930.duckdb`, 2.2 GiB) was deleted from the NUC's OWC enclosure on 2026-05-15 as part of the broader embedding-and-snapshot cleanup. Verified to contain only the standard EMA analytics tables filtered to the 3M subset — no embeddings.
-- The deletion record is documented at `~/Desktop/markdown/owc-embeddings-deletion-2026-05-15/DELETION-RECORD-2026-05-15.md` (follow-up #4). That file is the canonical record of what was deleted and the rationale.
-- The architecture design doc lives at `~/from-intel/Desktop/Desktop/markdown/satellite-ontology-embedding-architecture.md` on the Intel-MBP migration staging tree. Not in this repo; not on Desktop; not backed up.
-- The NERSC portal at `https://portal.nersc.gov/project/m3408/biosamples_duckdb/` still hosts the 3M-row DuckDB and Parquet exports (project `m3408` is NMDC's NERSC project). Reachable, but stale — predates Feb 2026's pipeline rebuild.
+- The local working copy of `contextualizer-ai/env-embeddings` and the ~41 GB of satellite-embedding source data were not retained and were not backed up. The GitHub repo presumably still exists but is not wired into any of EMA's current pipelines.
+- The metadata-side DuckDB snapshot (`ncbi_metadata_3M_biosamples_flat_20250930.duckdb`, 2.2 GiB) was deleted on 2026-05-15 as part of the embedding-and-snapshot cleanup. It contained only the standard EMA analytics tables filtered to the 3M subset, no embeddings.
+- The architecture design for the join was not preserved in this repository and is not publicly available.
+- The NERSC portal at `https://portal.nersc.gov/project/m3408/biosamples_duckdb/` still hosts the 3M-row DuckDB and Parquet exports (project `m3408` is NMDC's NERSC project). Reachable, but stale: it predates the Feb 2026 pipeline rebuild.
 
 ## Why we removed the filter targets
 
@@ -45,7 +44,6 @@ The targets were removed in the same commit that introduced this doc.
 
 ## Cross-refs
 
-- `~/Desktop/markdown/owc-embeddings-deletion-2026-05-15/DELETION-RECORD-2026-05-15.md` — deletion record, especially follow-up #4
-- `docs/pipeline-rebuild-pain-points.md` — NERSC portal reference and the 3M→51.7M rebuild context
-- `docs/data-products-inventory.md` — historical inventory of DuckDB tables
-- `unorganized/September-2025-Biosample-DuckDB-documentation.html` — per-table schema for the 3M subset, from when the project was active
+- `docs/pipeline-rebuild-pain-points.md`: NERSC portal reference and the 3M to 51.7M rebuild context
+- `docs/data-products-inventory.md`: historical inventory of DuckDB tables
+- `unorganized/September-2025-Biosample-DuckDB-documentation.html`: per-table schema for the 3M subset, from when the project was active


### PR DESCRIPTION
Copilot reviewed #444, #438, #429, and #450 but they were merged before its inline comments were addressed. This applies the valid ones.

- **#438 drop recipe (real bug + misleading comment):** parse `MONGO_URI` with a non-executing dotenv reader instead of sourcing `.env` as a shell script (which mishandles URIs containing `&` and would run any code in the file), and pass it to `mongosh` via the environment, not argv, so the credential is not visible in process listings. Fix the comment and the help text (`BASE_URL`/`OUTPUT_FILE` are optional; literal path example).
- **#450 `mixs.Makefile`:** rename `LLM` to `LLM_CLI` so a users exported `LLM` env var cannot clobber it (Make imports the environment).
- **#429 history doc:** rewrite as an impersonal project record; drop unresolvable local-machine paths and per-person references, keep the facts.
- **#444 YAML:** add the `---` document-start marker that `.yamlfmt` and `codeql.yml` use; harden the gitleaks download with `curl -f`.

Declined: Copilots claim that the gitleaks install to `/usr/local/bin` would fail on hosted runners. That step has run green on every secret-scan job, so the path is writable. Took the `curl -f` half of that suggestion anyway.