### PR TITLE
Resolve CodeQL code-quality standard findings

### DIFF
--- a/external_metadata_awareness/adhoc/cborg_test.py
+++ b/external_metadata_awareness/adhoc/cborg_test.py
@@ -34,5 +34,5 @@ for m in models:
         )
 
         print(f"Model: {m}\nResponse: {response.choices[-1].message.content}")
-    except:
+    except Exception:
         print(f"Error calling model {m}")

--- a/external_metadata_awareness/adhoc/infer_first_committer.py
+++ b/external_metadata_awareness/adhoc/infer_first_committer.py
@@ -1,12 +1,12 @@
 import csv
 import os
+import sys
 import click
-import pprint
 from tqdm import tqdm
 
 from typing import List, Any, Dict
 from dotenv import load_dotenv
-from github import Github, Repository, RateLimitExceededException, UnknownObjectException, GithubException
+from github import Github, RateLimitExceededException, UnknownObjectException, GithubException
 
 dotenv_path = os.path.join('local', '.env')
 load_dotenv(dotenv_path, verbose=True)
@@ -24,7 +24,7 @@ def main(org_name: str, repo_type: str, output_file: str):
     github_token = os.environ.get("GITHUB_TOKEN")
     if not github_token:
         print("Please set the GITHUB_TOKEN environment variable.")
-        exit(1)
+        sys.exit(1)
 
     repos = get_all_org_repos(org_name, github_token, repo_type)
     commit_data = []

--- a/external_metadata_awareness/analyze_collection_flatness.py
+++ b/external_metadata_awareness/analyze_collection_flatness.py
@@ -16,7 +16,7 @@ import logging
 import os
 import time
 from collections import Counter
-from typing import Dict, Any, List
+from typing import Dict, Any
 
 from external_metadata_awareness.mongodb_connection import get_mongo_client
 

--- a/external_metadata_awareness/build_prompt_from_template.py
+++ b/external_metadata_awareness/build_prompt_from_template.py
@@ -1,5 +1,4 @@
 import click
-import os
 import yaml
 
 

--- a/external_metadata_awareness/class_slot_flattening.py
+++ b/external_metadata_awareness/class_slot_flattening.py
@@ -2,7 +2,6 @@ import click
 import pandas as pd
 from linkml_runtime import SchemaView
 from jsonasobj2 import as_dict
-import os
 import collections.abc
 from linkml_runtime.utils.yamlutils import extended_int
 

--- a/external_metadata_awareness/combine_cache_files.py
+++ b/external_metadata_awareness/combine_cache_files.py
@@ -72,10 +72,6 @@ def merge_caches(source_files, target_file):
             
             # Process each table
             for table in ['responses', 'redirects']:
-                # Get column names
-                source_cur.execute(f"PRAGMA table_info({table})")
-                columns = [col[1] for col in source_cur.fetchall()]
-                
                 # Count records before importing
                 target_cur.execute(f"SELECT COUNT(*) FROM {table}")
                 before_count = target_cur.fetchone()[0]

--- a/external_metadata_awareness/extract_nmdc_doi_inventory.py
+++ b/external_metadata_awareness/extract_nmdc_doi_inventory.py
@@ -2,7 +2,6 @@
 
 import csv
 import re
-import sys
 from collections import Counter
 
 import click

--- a/external_metadata_awareness/fetch_document.py
+++ b/external_metadata_awareness/fetch_document.py
@@ -2,6 +2,7 @@
 """Minimal script to fetch one document from a MongoDB collection."""
 
 import json
+import sys
 from urllib.parse import urlparse
 import click
 from bson import json_util
@@ -45,7 +46,7 @@ def fetch_document(mongo_uri, env_file, collection, verbose):
 
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/external_metadata_awareness/fetch_github_releases.py
+++ b/external_metadata_awareness/fetch_github_releases.py
@@ -1,7 +1,6 @@
 import os
 import click
 import requests
-from pathlib import Path
 from typing import Optional, Dict
 
 def get_github_api_url(owner: str, repo: str) -> str:

--- a/external_metadata_awareness/mongo_js_executor.py
+++ b/external_metadata_awareness/mongo_js_executor.py
@@ -10,7 +10,6 @@ import os
 import sys
 import subprocess
 import click
-from pymongo import uri_parser
 
 from external_metadata_awareness.mongodb_connection import get_mongo_client
 

--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -3,7 +3,6 @@ import os
 import sys
 import re
 import argparse
-import json
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -137,7 +136,7 @@ def main():
     try:
         # Get connection info in dry-run mode if not connecting
         if not args.connect and not args.command:
-            result = get_mongo_client(
+            get_mongo_client(
                 mongo_uri=args.uri,
                 env_file=args.env_file,
                 debug=args.verbose,

--- a/external_metadata_awareness/normalize_satisfying_biosamples.py
+++ b/external_metadata_awareness/normalize_satisfying_biosamples.py
@@ -213,7 +213,7 @@ def normalize_biosamples(
     click.echo(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Normalizing collection_date to YYYY-MM-DD format...")
     if 'collection_date' in df.columns:
         # Get unique values and sort alphabetically
-        unique_dates = sorted(df['collection_date'].unique(), key=lambda x: str(x))
+        unique_dates = sorted(df['collection_date'].unique(), key=str)
         total_unique = len(unique_dates)
         click.echo(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]   Found {total_unique:,} unique date values")
 
@@ -246,7 +246,7 @@ def normalize_biosamples(
     click.echo(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Normalizing lat_lon to separate latitude/longitude columns (+/- DD.dddd)...")
     if 'lat_lon' in df.columns:
         # Get unique values and sort alphabetically
-        unique_coords = sorted(df['lat_lon'].unique(), key=lambda x: str(x))
+        unique_coords = sorted(df['lat_lon'].unique(), key=str)
         total_unique = len(unique_coords)
         click.echo(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]   Found {total_unique:,} unique coordinate values")
 

--- a/external_metadata_awareness/populate_env_triads_collection.py
+++ b/external_metadata_awareness/populate_env_triads_collection.py
@@ -22,6 +22,7 @@ def recreate_index(collection, keys, **kwargs):
         collection.drop_index(index_name)
         print(f"   ↪ Dropped existing index: {index_name}")
     except Exception:
+        # Index may not exist yet on a fresh collection; nothing to drop.
         pass
     collection.create_index(keys, **kwargs)
     print(f"   ↪ Created index: {index_name}")

--- a/external_metadata_awareness/predict_env_package_from_nmdc_context_authoritative_labels.py
+++ b/external_metadata_awareness/predict_env_package_from_nmdc_context_authoritative_labels.py
@@ -11,7 +11,6 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report
 from scipy.sparse import hstack
 
-import numpy as np
 
 # Initialize cache dictionaries
 ancestor_cache = {}
@@ -85,9 +84,7 @@ def get_hierarchy_terms(curie: str, adapter) -> dict:
     Returns:
         dict: Dictionary containing lists of ancestor and descendant terms.
     """
-    if curie in ancestor_cache:
-        ancestors = ancestor_cache[curie]
-    else:
+    if curie not in ancestor_cache:
         try:
             ancestors = list(adapter.ancestors(curie, predicates=[IS_A]))
             ancestor_cache[curie] = [adapter.label(ancestor) for ancestor in ancestors if ancestor]
@@ -95,9 +92,7 @@ def get_hierarchy_terms(curie: str, adapter) -> dict:
             print(f"Error retrieving ancestors for {curie}: {e}")
             ancestor_cache[curie] = []
 
-    if curie in descendant_cache:
-        descendants = descendant_cache[curie]
-    else:
+    if curie not in descendant_cache:
         try:
             descendants = list(adapter.descendants(curie, predicates=[IS_A]))
             descendant_cache[curie] = [adapter.label(descendant) for descendant in descendants if descendant]

--- a/external_metadata_awareness/sra_accession_pairs_tsv_to_mongo.py
+++ b/external_metadata_awareness/sra_accession_pairs_tsv_to_mongo.py
@@ -1,4 +1,3 @@
-import pymongo
 import csv
 import click
 import datetime

--- a/external_metadata_awareness/sra_parquet_to_mongodb.py
+++ b/external_metadata_awareness/sra_parquet_to_mongodb.py
@@ -4,7 +4,6 @@ import datetime
 import os
 import time
 from tqdm import tqdm
-from itertools import islice
 
 from external_metadata_awareness.mongodb_connection import get_mongo_client
 

--- a/external_metadata_awareness/xml_to_mongo.py
+++ b/external_metadata_awareness/xml_to_mongo.py
@@ -1,6 +1,4 @@
 import time
-import os
-from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 

--- a/mongo-js/aggregate_content_pairs.js
+++ b/mongo-js/aggregate_content_pairs.js
@@ -31,9 +31,9 @@ print(`[${new Date().toISOString()}] Running aggregation (may take 30-90 min for
 db.biosamples_attributes.aggregate([
     {
         $match: {
-            harmonized_name: {$exists: true, $ne: "", $ne: null},
-            content: {$exists: true, $ne: "", $ne: null},
-            accession: {$exists: true, $ne: "", $ne: null}
+            harmonized_name: {$exists: true, $nin: ["", null]},
+            content: {$exists: true, $nin: ["", null]},
+            accession: {$exists: true, $nin: ["", null]}
         }
     },
     // First $group: deduplicate (harmonized_name, content, accession) triples

--- a/mongo-js/count_bioprojects_step2a_dedupe_accessions.js
+++ b/mongo-js/count_bioprojects_step2a_dedupe_accessions.js
@@ -20,8 +20,8 @@ print(`[${new Date().toISOString()}] Running aggregation (may take 60-90 min for
 db.biosamples_attributes.aggregate([
     {
         $match: {
-            harmonized_name: {$exists: true, $ne: "", $ne: null},
-            accession: {$exists: true, $ne: "", $ne: null}
+            harmonized_name: {$exists: true, $nin: ["", null]},
+            accession: {$exists: true, $nin: ["", null]}
         }
     },
     // Deduplicate harmonized_name + accession pairs

--- a/mongo-js/count_bioprojects_usage_stats_step2.js
+++ b/mongo-js/count_bioprojects_usage_stats_step2.js
@@ -22,8 +22,8 @@ print(`[${new Date().toISOString()}] Running aggregation (may take 40-80 min - i
 db.biosamples_attributes.aggregate([
     {
         $match: {
-            harmonized_name: {$exists: true, $ne: "", $ne: null},
-            accession: {$exists: true, $ne: "", $ne: null}
+            harmonized_name: {$exists: true, $nin: ["", null]},
+            accession: {$exists: true, $nin: ["", null]}
         }
     },
     // First $group: deduplicate harmonized_name + accession pairs

--- a/mongo-js/count_biosamples_flattened_field_usage.js
+++ b/mongo-js/count_biosamples_flattened_field_usage.js
@@ -25,7 +25,7 @@ db.biosamples_flattened.aggregate([
     { 
         $match: { 
             "kvArray.k": { $nin: ["_id", "accession"] },
-            "kvArray.v": { $ne: null, $ne: "", $exists: true }
+            "kvArray.v": { $nin: [null, ""], $exists: true }
         } 
     },
     // Count usage per harmonized field name

--- a/mongo-js/count_biosamples_usage_stats_step1.js
+++ b/mongo-js/count_biosamples_usage_stats_step1.js
@@ -21,8 +21,8 @@ print(`[${new Date().toISOString()}] Running aggregation (may take 30-60 min for
 db.biosamples_attributes.aggregate([
     {
         $match: {
-            harmonized_name: {$exists: true, $ne: "", $ne: null},
-            accession: {$exists: true, $ne: "", $ne: null}
+            harmonized_name: {$exists: true, $nin: ["", null]},
+            accession: {$exists: true, $nin: ["", null]}
         }
     },
     // First $group: deduplicate harmonized_name + accession pairs

--- a/mongo-js/count_unit_assertions.js
+++ b/mongo-js/count_unit_assertions.js
@@ -29,7 +29,7 @@ db.unit_assertion_counts.drop();
 db.biosamples_attributes.aggregate([
     {
         $match: {
-            unit: { $exists: true, $ne: null, $ne: "" },
+            unit: { $exists: true, $nin: [null, ""] },
             harmonized_name: { $exists: true, $ne: null }
         }
     },

--- a/mongo-js/flatten_env_triads_multi_component.js
+++ b/mongo-js/flatten_env_triads_multi_component.js
@@ -102,7 +102,7 @@ db.env_triads.aggregate([
     {
         // Include all records: those with components AND those with only raw_original
         $match: {
-            raw_original: { $exists: true, $ne: null, $ne: "" }
+            raw_original: { $exists: true, $nin: [null, ""] }
         }
     },
     {

--- a/notebooks/core.py
+++ b/notebooks/core.py
@@ -1,4 +1,3 @@
-import pprint
 
 import pymongo
 


### PR DESCRIPTION
Clears all 37 CodeQL "Standard findings" (21 maintainability + 16 reliability). Counts reconciled exactly against the Security and quality tab.

**Maintainability (21)**
- 15 unused imports removed (`.py` only, matching the CodeQL scan scope).
- 4 unused local variables: dead `PRAGMA` fetch in `combine_cache_files`; dead cache-hit branches in `predict_env_package` (restructured to `if curie not in cache`); unused dry-run `result` in `mongodb_connection`.
- 2 unnecessary lambdas (`key=lambda x: str(x)` to `key=str`).

**Reliability (16)**
- **12 "overwritten property" bugs** in `mongo-js`. Each filter wrote the same key twice, e.g. `{$exists: true, $ne: "", $ne: null}`; JS keeps only the last, so the empty-string exclusion was silently dropped. Rewritten to `{$exists: true, $nin: ["", null]}`. This matches the already-correct pattern that `derive_sra_pairs_into_ncbi.js` documents in a comment.
  - **Behavior change worth a careful look:** these aggregations now actually exclude empty-string values (the intended behavior). Downstream collection counts may shift slightly as a result.
- 2 `exit()`/`quit()` replaced with `sys.exit()` (+ `import sys`).
- 1 bare `except:` narrowed to `except Exception:`.
- 1 empty except given an explanatory comment.

**Deliberately not changed**
- The 40+ "catch broad `Exception`" cases CodeQL did not flag (likely intentional).
- Notebook (`.ipynb`) findings, which are outside the CodeQL scan scope.

Verified: all 18 changed `.py` compile, all 7 changed `.js` parse, and ruff confirms the targeted rules are clear in scope.

Not auto-merged: the JS change has data-behavior implications, so it should get a human + Copilot review first.