### PR TITLE
Add ruff lint check (CI) for code-quality rules

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,21 @@
+---
+name: ruff
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install ruff
+        run: python3 -m pip install ruff==0.15.17
+      - name: Lint (code-quality rules; config in pyproject.toml [tool.ruff])
+        run: ruff check .

--- a/external_metadata_awareness/find_nmdc_measurement_slots.py
+++ b/external_metadata_awareness/find_nmdc_measurement_slots.py
@@ -32,7 +32,7 @@ def summarize_slot_range_pairs(nmdc_path, output_path):
     grouped["range_is_nmdc_class"] = grouped["range"].apply(lambda r: r in known_classes)
 
     # Convert domain list to string for export
-    grouped["domain"] = grouped["domain"].apply(lambda lst: ", ".join(lst))
+    grouped["domain"] = grouped["domain"].apply(", ".join)
 
     # Save result
     grouped.to_csv(output_path, sep="\t", index=False)

--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -66,7 +66,6 @@ def safe_expand(curie):
     try:
         return converter.expand(curie.upper())
     except Exception:
-        # print(f"CURIE: {curie} - Expansion error: {e}")
         return None
 
 
@@ -85,7 +84,6 @@ def get_bioportal_info(term_uri, prefix, api_key):
         mappings_link = data.get("links", {}).get("mappings")
         return {"mappings_link": mappings_link, "data": data}
     except Exception:
-        # print(f"Error fetching BioPortal info for {url}: {e}")
         return None
 
 
@@ -103,7 +101,6 @@ def get_mapped_term_info(self_link, api_key):
         response.raise_for_status()
         return response.json()
     except Exception:
-        # print(f"Error fetching mapped term info from {self_link}: {e}")
         return {}
 
 
@@ -155,7 +152,6 @@ def fetch_mappings(mappings_url, api_key, verbose=False):
             pprint.pprint(accepted_mappings)
         return accepted_mappings
     except Exception:
-        # print(f"Error fetching mappings from {mappings_url}: {e}")
         return []
 
 

--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -65,7 +65,7 @@ def safe_expand(curie):
     """Expand a CURIE using the converter."""
     try:
         return converter.expand(curie.upper())
-    except Exception as e:
+    except Exception:
         # print(f"CURIE: {curie} - Expansion error: {e}")
         return None
 
@@ -84,7 +84,7 @@ def get_bioportal_info(term_uri, prefix, api_key):
         data = response.json()
         mappings_link = data.get("links", {}).get("mappings")
         return {"mappings_link": mappings_link, "data": data}
-    except Exception as e:
+    except Exception:
         # print(f"Error fetching BioPortal info for {url}: {e}")
         return None
 
@@ -102,7 +102,7 @@ def get_mapped_term_info(self_link, api_key):
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         return response.json()
-    except Exception as e:
+    except Exception:
         # print(f"Error fetching mapped term info from {self_link}: {e}")
         return {}
 
@@ -154,7 +154,7 @@ def fetch_mappings(mappings_url, api_key, verbose=False):
         if verbose:
             pprint.pprint(accepted_mappings)
         return accepted_mappings
-    except Exception as e:
+    except Exception:
         # print(f"Error fetching mappings from {mappings_url}: {e}")
         return []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,12 @@ DEP002 = [
 #  10. git-filter-repo:
 #    - No direct usage in code, but mentioned in CLAUDE.md
 #    - May be used in manual git operations or scripting
+
+[tool.ruff]
+# Lints only the source tree; notebooks are out of CodeQL's scan scope too.
+extend-exclude = ["*.ipynb"]
+
+[tool.ruff.lint]
+# Code-quality rules matching the CodeQL standard findings resolved in #454:
+# unused import, unused local, bare except, exit()/quit(), unnecessary lambda.
+select = ["F401", "F841", "E722", "PLR1722", "PLW0108"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,8 @@ DEP002 = [
 #    - May be used in manual git operations or scripting
 
 [tool.ruff]
-# Lints only the source tree; notebooks are out of CodeQL's scan scope too.
+# `ruff check .` lints every .py file in the repo; only Jupyter notebooks
+# are excluded, matching CodeQL's scan scope (which also skips .ipynb).
 extend-exclude = ["*.ipynb"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Prevents the code-quality findings from recurring by linting on every PR/push.

- New `.github/workflows/ruff.yml` runs `ruff check .` (ruff pinned to 0.15.17, the version used to validate #454).
- `[tool.ruff]` config in `pyproject.toml` enforces the rule set equivalent to the CodeQL standard findings resolved in #454: `F401` (unused import), `F841` (unused local), `E722` (bare except), `PLR1722` (`exit()`/`quit()`), `PLW0108` (unnecessary lambda). Notebooks (`.ipynb`) are excluded, matching the CodeQL scan scope.
- Fixes the 5 remaining occurrences so CI starts green: 4 unused exception bindings in `new_bioportal_curie_mapper`, 1 unnecessary lambda in `find_nmdc_measurement_slots`.

Deliberately not enforcing the broad-`Exception` (`BLE001`) rule, since CodeQL did not flag those and they are likely intentional.