### PR TITLE
Add Dependabot auto-merge for patch/minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+---
+name: Dependabot auto-merge
+
+# Enables auto-merge for Dependabot patch and minor updates so they merge on
+# their own once the required status checks pass. Major updates are left for a
+# human to review. Requires repo setting "Allow auto-merge" and at least one
+# required status check on the default branch.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Eliminates the manual rebase-and-merge cycling that routine Dependabot PRs require (today there were ~11 of them, merged one at a time).

- New `.github/workflows/dependabot-auto-merge.yml` uses `dependabot/fetch-metadata` (SHA-pinned, v2) and enables GitHub auto-merge (`gh pr merge --auto --squash`) for `version-update:semver-patch` and `version-update:semver-minor` updates only.
- **Major** updates are intentionally left for a human to review.
- Auto-merge still respects branch protection, so a PR only merges after the required status checks pass and the branch is up to date. Nothing merges that CI has not approved.

Depends on the repo `Allow auto-merge` setting being enabled (being turned on separately).