### PR TITLE
Group Dependabot updates to reduce PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -5,9 +6,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Adds `groups` to `.github/dependabot.yml` so related bumps arrive as one PR instead of many (this morning produced ~11 separate Dependabot PRs).

- **github-actions**: all action bumps grouped into one PR.
- **pip**: minor/patch bumps grouped into one PR; **major** bumps stay separate so they get individual review.

Pairs with the auto-merge workflow (#457): grouped patch/minor PRs will pass CI and merge themselves, so routine maintenance becomes roughly one self-merging PR per ecosystem per week.