### PR TITLE
Entry-point smoke tests + remove 4 dead entry points (#470 tier 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 ---
 name: build
 
-# Validates that the dependency tree still resolves and installs, and that
-# poetry.lock is in sync with pyproject.toml. There is no test suite to run
-# yet, so this is the "does it still build" check for PRs.
+# Validates that the dependency tree resolves and installs, that poetry.lock is
+# in sync with pyproject.toml, and runs the smoke tests (entry points import and
+# click commands respond to --help). No MongoDB or network is needed.
 
 on:
   push:
@@ -29,3 +29,5 @@ jobs:
         run: poetry check --lock
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
+      - name: Smoke tests (entry points + CLI --help)
+        run: poetry run pytest -q

--- a/poetry.lock
+++ b/poetry.lock
@@ -8744,4 +8744,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "32995eb7110d1ea307876f7a241d1b5a42db6d4e91dc15f3f0e169f1ae087e9c"
+content-hash = "ab791a67883ae1375e80a89c8253668f5b04198d5387b4928eb88fdc1aae1a4a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1654,7 +1654,7 @@ version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
@@ -2821,7 +2821,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -5246,7 +5246,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -5912,7 +5912,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -6238,21 +6238,21 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.10"
-groups = ["main"]
+python-versions = ">=3.9"
+groups = ["main", "dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1.0.1"
-packaging = ">=22"
+iniconfig = ">=1"
+packaging = ">=20"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -8266,11 +8266,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "typing-inspection"
@@ -8743,4 +8744,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "aec36e9a25b5ee0ac6211d63a131ad331b32d9e44d43dc389ac1de2e4df31fed"
+content-hash = "32995eb7110d1ea307876f7a241d1b5a42db6d4e91dc15f3f0e169f1ae087e9c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ nmdc-submission-schema = "^11.17.0"
 [tool.poetry.group.dev.dependencies]
 deptry = ">=0.23,<0.26"
 pytest = ">=8.3,<9"
+tomli = { version = ">=2.0,<3", python = "<3.11" }
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ nmdc-submission-schema = "^11.17.0"
 
 [tool.poetry.group.dev.dependencies]
 deptry = ">=0.23,<0.26"
+pytest = ">=8.3,<9"
 
 [build-system]
 requires = ["poetry-core"]
@@ -70,7 +71,6 @@ build-backend = "poetry.core.masonry.api"
 biosample-json-to-context-tsv = 'external_metadata_awareness.biosample_json_to_context_tsv:create_biosample_table'
 build-prompt-from-template = 'external_metadata_awareness.build_prompt_from_template:process_files'
 count-xml-paths = 'external_metadata_awareness.count_xml_paths:main'
-get-extension-unique-slots = 'external_metadata_awareness.get_extension_unique_slots:process_json'
 random-sample-resources = 'external_metadata_awareness.adhoc.random_sample_resources:downsample_json_resources'
 xml-to-mongo = 'external_metadata_awareness.xml_to_mongo:load_xml_to_mongodb'
 
@@ -86,12 +86,9 @@ populate-env-triads-collection = 'external_metadata_awareness.populate_env_triad
 normalize-biosample-measurements = 'external_metadata_awareness.normalize_biosample_measurements:main'
 export-sra-accession-pairs = 'external_metadata_awareness.export_sra_accession_pairs:main'
 extract-ncbi-packages-fields = 'external_metadata_awareness.extract_all_ncbi_packages_fields:main'
-infer-biosample-env-context-curies = 'external_metadata_awareness.infer_biosample_env_context_obo_curies:main'
 load-bioprojects-into-mongodb = 'external_metadata_awareness.load_acceptable_sized_leaf_bioprojects_into_mongodb:main'
-mongodb-biosamples-to-duckdb = 'external_metadata_awareness.mongodb_biosamples_to_duckdb:main'
 mongo-connect = 'external_metadata_awareness.mongodb_connection:main'
 mongo-js-executor = 'external_metadata_awareness.mongo_js_executor:main'
-ncbi-package-info-to-duckdb = 'external_metadata_awareness.ncbi_package_info_to_duck_db:main'
 prioritize-lexmatch-results = 'external_metadata_awareness.prioritize_lexmatch_results:main'
 sra-accession-pairs-to-mongo = 'external_metadata_awareness.sra_accession_pairs_tsv_to_mongo:load_tsv_to_mongo'
 sra-parquet-to-mongodb = 'external_metadata_awareness.sra_parquet_to_mongodb:insert_parquet_to_mongo'
@@ -177,3 +174,9 @@ extend-exclude = ["*.ipynb"]
 # Code-quality rules matching the CodeQL standard findings resolved in #454:
 # unused import, unused local, bare except, exit()/quit(), unnecessary lambda.
 select = ["F401", "F841", "E722", "PLR1722", "PLW0108"]
+
+[tool.pytest.ini_options]
+# Only collect the dedicated test suite; do not auto-discover the adhoc
+# scripts (e.g. cborg_test.py matches pytest's *_test.py pattern and has
+# import-time side effects).
+testpaths = ["tests"]

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -14,8 +14,12 @@ covered by the load test; their ``--help`` is just not exercised here.
 """
 
 import importlib
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 import click
 import pytest

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,0 +1,46 @@
+"""Smoke tests for the console_scripts entry points (issue #470, tier 1).
+
+These catch the most common dependency and refactor breakage without needing
+MongoDB or network access:
+
+- Every entry-point target must import and expose its referenced function.
+  This catches dead entries (a renamed/deleted module) and any import-time
+  breakage from a dependency bump.
+- For click-based entry points, ``--help`` must exit 0 (via click's CliRunner,
+  which does not run the command body, so nothing connects or hangs).
+
+Entry points that are not click commands (e.g. argparse-based) are still
+covered by the load test; their ``--help`` is just not exercised here.
+"""
+
+import importlib
+import tomllib
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+_SCRIPTS = tomllib.loads(_PYPROJECT.read_text())["tool"]["poetry"].get("scripts", {})
+_ENTRY_POINTS = sorted(_SCRIPTS.items())
+_IDS = [name for name, _ in _ENTRY_POINTS]
+
+
+@pytest.mark.parametrize("name,target", _ENTRY_POINTS, ids=_IDS)
+def test_entry_point_loads(name, target):
+    """The target module imports and the referenced function exists."""
+    module_path, _, func_name = target.partition(":")
+    module = importlib.import_module(module_path)
+    assert hasattr(module, func_name), f"{module_path} has no attribute {func_name!r}"
+
+
+@pytest.mark.parametrize("name,target", _ENTRY_POINTS, ids=_IDS)
+def test_click_entry_point_help(name, target):
+    """click-based entry points respond to --help with exit code 0."""
+    module_path, _, func_name = target.partition(":")
+    obj = getattr(importlib.import_module(module_path), func_name)
+    if not isinstance(obj, click.BaseCommand):
+        pytest.skip(f"{name} is not a click command")
+    result = CliRunner().invoke(obj, ["--help"])
+    assert result.exit_code == 0, f"{name} --help exited {result.exit_code}:\n{result.output}"


### PR DESCRIPTION
Implements tier 1 of #470: a cheap test layer that catches the most common dependency/refactor breakage, no MongoDB or network needed.

**`tests/test_entry_points.py`**
- Every `console_scripts` target must import and expose its function (catches dead entries and import-time breakage from dependency bumps).
- click-based entry points must respond to `--help` with exit 0, via clicks `CliRunner` (the command body never runs, so nothing connects or hangs).
- Result locally: **59 passed, 1 skipped** (`mongo-connect` is argparse, not click, so it gets the load test but not the `--help` test).

**Removes 4 dead entry points** whose modules no longer exist (this is the latent breakage the test surfaced):
`get-extension-unique-slots`, `infer-biosample-env-context-curies`, `mongodb-biosamples-to-duckdb`, `ncbi-package-info-to-duckdb`.

**Wiring**
- Adds `pytest` to the dev group and runs `poetry run pytest` in the build workflow.
- Scopes collection to `tests/` so the adhoc `cborg_test.py` (matches pytest `*_test.py` and has import-time side effects) is not auto-discovered. Side note: that misnamed adhoc script is part of why #467 (drop `openai`) is worth doing.

This is the safety net for the dependency cleanups in #467/#468 and the foundation for #470 tiers 2-5. Advances #202 and #315.