### PR TITLE
Deepen tests: notebook syntax smoke + env-triad splitter units (#470)

### DIFF
--- a/tests/test_env_triad_splitter.py
+++ b/tests/test_env_triad_splitter.py
@@ -1,0 +1,56 @@
+"""Unit tests for the pure env-triad value-splitting functions (#470 tier 4).
+
+These functions parse free-text environmental-context values into components;
+they take strings and return strings/dicts with no I/O, so they are cheap to
+test and guard the core parsing logic against refactors.
+"""
+
+from external_metadata_awareness.new_env_triad_values_splitter import (
+    extract_components,
+    is_digits_only,
+    make_plain_component,
+    normalize_label,
+)
+
+
+def test_is_digits_only():
+    assert is_digits_only("123") is True
+    assert is_digits_only("12a") is False
+    assert is_digits_only("") is False
+    assert is_digits_only(None) is False
+
+
+def test_normalize_label_lowercases_and_replaces_punctuation():
+    assert normalize_label("Soil_Sample") == "soil sample"
+    assert normalize_label("ENVO:00001  Foo") == "envo 00001 foo"
+
+
+def test_make_plain_component():
+    c = make_plain_component("ENVO soil")
+    assert c["label"] == "envo soil"
+    assert c["lingering_envo"] is True
+    assert c["label_digits_only"] is False
+    assert c["raw"] == "ENVO soil"
+
+
+def test_extract_components_non_string_returns_empty():
+    assert extract_components(123) == []
+
+
+def test_extract_components_plain_token():
+    comps = extract_components("soil")
+    assert len(comps) == 1
+    assert comps[0]["label"] == "soil"
+
+
+def test_extract_components_bracketed_curie():
+    comps = extract_components("soil [ENVO:00001]")
+    assert len(comps) == 1
+    assert comps[0]["prefix_uc"] == "ENVO"
+    assert comps[0]["local"] == "00001"
+    assert comps[0]["label"] == "soil"
+
+
+def test_extract_components_splits_on_comma():
+    comps = extract_components("soil, water")
+    assert [c["label"] for c in comps] == ["soil", "water"]

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,56 @@
+"""Notebook syntax smoke test (#470 tier 2).
+
+Every notebook's code cells must be syntactically valid Python. This does NOT
+execute notebooks (they need MongoDB / data / network); it parses each .ipynb as
+JSON and ast-parses the code cells, so it catches half-edited or broken
+notebooks and syntax errors introduced by bulk edits, with no external services.
+
+IPython line magics (`%`, `!`, `?`) are blanked and whole cell-magic cells
+(`%%bash`, `%%time`, ...) are skipped, since those are not plain Python.
+Top-level `await` is allowed (valid in notebooks).
+"""
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_NOTEBOOKS = sorted((_REPO / "notebooks").rglob("*.ipynb"))
+_IDS = [str(p.relative_to(_REPO)) for p in _NOTEBOOKS]
+
+
+def _is_cell_magic(src: str) -> bool:
+    for line in src.splitlines():
+        if line.strip():
+            return line.lstrip().startswith("%%")
+    return False
+
+
+def _strip_line_magics(src: str) -> str:
+    return "\n".join(
+        "" if line.lstrip().startswith(("%", "!", "?")) else line
+        for line in src.splitlines()
+    )
+
+
+@pytest.mark.parametrize("nb_path", _NOTEBOOKS, ids=_IDS)
+def test_notebook_code_cells_parse(nb_path):
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    for i, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        if _is_cell_magic(src):
+            continue
+        code = _strip_line_magics(src)
+        try:
+            compile(
+                code,
+                f"{nb_path.name}#cell{i}",
+                "exec",
+                flags=ast.PyCF_ONLY_AST | ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+            )
+        except SyntaxError as e:  # noqa: PERF203
+            pytest.fail(f"{nb_path.relative_to(_REPO)} code cell {i}: {e}")

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -21,6 +21,12 @@ _NOTEBOOKS = sorted((_REPO / "notebooks").rglob("*.ipynb"))
 _IDS = [str(p.relative_to(_REPO)) for p in _NOTEBOOKS]
 
 
+def test_notebooks_were_discovered():
+    """Fail loudly if discovery finds nothing (e.g. a path rename or shallow
+    checkout), so the smoke test can never silently become a no-op."""
+    assert _NOTEBOOKS, "no .ipynb discovered under notebooks/"
+
+
 def _is_cell_magic(src: str) -> bool:
     for line in src.splitlines():
         if line.strip():


### PR DESCRIPTION
Advances #470 (tiers 2 and 4), building on the entry-point smoke test.

- **`tests/test_notebooks.py`** — every notebook code cell must be syntactically valid Python. Parses each `.ipynb` as JSON and `ast`-parses code cells (does **not** execute them, so no MongoDB/data/network). Catches half-edited or broken notebooks. Handles IPython magics and top-level `await`. Covers all 49 notebooks.
- **`tests/test_env_triad_splitter.py`** — unit tests for the pure parsing functions (`is_digits_only`, `normalize_label`, `make_plain_component`, `extract_components`). Expectations were verified against the live functions first.

Suite: **115 passed, 1 skipped** (was 59/1). Runs in the existing `build` job; no new services. The notebook tier here is also the groundwork for verifying a future pandas 3.x bump (#469).