### PR TITLE
Convert all scripts to click

### DIFF
--- a/external_metadata_awareness/adhoc/nmdc_collection_stats.py
+++ b/external_metadata_awareness/adhoc/nmdc_collection_stats.py
@@ -11,7 +11,7 @@ import pandas as pd
 def main(api_url, tsv_out_filename):
     """Fetch NMDC collection storage stats and write them to a TSV file."""
     url = api_url
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
 
     if response.status_code != 200:
         print(f"Failed to fetch data. Status code: {response.status_code}")

--- a/external_metadata_awareness/adhoc/nmdc_collection_stats.py
+++ b/external_metadata_awareness/adhoc/nmdc_collection_stats.py
@@ -1,11 +1,16 @@
+import click
 import requests
 import pandas as pd
 
 
-def make_collection_stats_table():
-    # Fetch the data from the API
-    url = "https://api.microbiomedata.org/nmdcschema/collection_stats"
-    tsv_out_filename = "nmdc_collection_stats.tsv"
+@click.command()
+@click.option("--api-url", default="https://api.microbiomedata.org/nmdcschema/collection_stats",
+              show_default=True, help="NMDC collection_stats API endpoint.")
+@click.option("--output", "tsv_out_filename", default="nmdc_collection_stats.tsv",
+              show_default=True, help="Path of the TSV file to write.")
+def main(api_url, tsv_out_filename):
+    """Fetch NMDC collection storage stats and write them to a TSV file."""
+    url = api_url
     response = requests.get(url)
 
     if response.status_code != 200:
@@ -34,4 +39,4 @@ def make_collection_stats_table():
 
 
 if __name__ == "__main__":
-    make_collection_stats_table()
+    main()

--- a/external_metadata_awareness/combine_cache_files.py
+++ b/external_metadata_awareness/combine_cache_files.py
@@ -8,6 +8,8 @@ import sqlite3
 import os
 from pathlib import Path
 
+import click
+
 # Define the source cache files and target combined cache
 SOURCE_FILES = [
     'requests_cache.sqlite',
@@ -115,9 +117,29 @@ def merge_caches(source_files, target_file):
     print(f"Total redirects in combined cache: {redirects_count}")
 
 
-if __name__ == "__main__":
+@click.command()
+@click.option(
+    "--source",
+    "sources",
+    multiple=True,
+    default=SOURCE_FILES,
+    show_default=True,
+    help="requests-cache SQLite file to merge (repeatable).",
+)
+@click.option(
+    "--output",
+    default=COMBINED_CACHE,
+    show_default=True,
+    help="Path of the combined cache file to create.",
+)
+def main(sources, output):
+    """Combine multiple requests-cache SQLite files into a single cache file."""
     print("Starting cache merge operation...")
-    merge_caches(SOURCE_FILES, COMBINED_CACHE)
-    print(f"\nSuccessfully created combined cache at: {COMBINED_CACHE}")
+    merge_caches(list(sources), output)
+    print(f"\nSuccessfully created combined cache at: {output}")
     print("NOTE: This is a new file that doesn't affect the existing cache files.")
     print("To use it, you'll need to update your application code to point to this file.")
+
+
+if __name__ == "__main__":
+    main()

--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -2,12 +2,12 @@ import logging
 import os
 import sys
 import re
-import argparse
 import subprocess
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse, urlunparse
 
+import click
 from dotenv import load_dotenv
 import pymongo
 from pymongo import uri_parser
@@ -123,28 +123,26 @@ def get_mongo_client(
     return client
 
 
-def main():
-    """Command-line interface for testing MongoDB connection parameters."""
-    parser = argparse.ArgumentParser(description="Test MongoDB connection using a URI and optional env file")
-    parser.add_argument("--uri", required=True, help="MongoDB connection URI (must start with mongodb:// and include database name)")
-    parser.add_argument("--env-file", help="Path to .env file for credentials (should contain MONGO_USER and MONGO_PASSWORD)")
-    parser.add_argument("--verbose", action="store_true", help="Show verbose output")
-    parser.add_argument("--connect", action="store_true", help="Actually connect to the database")
-    parser.add_argument("--command", help="MongoDB command to execute (must be valid JavaScript/MongoDB shell command)")
-    args = parser.parse_args()
-    
+@click.command()
+@click.option("--uri", required=True, help="MongoDB connection URI (must start with mongodb:// and include database name)")
+@click.option("--env-file", "env_file", help="Path to .env file for credentials (should contain MONGO_USER and MONGO_PASSWORD)")
+@click.option("--verbose", is_flag=True, help="Show verbose output")
+@click.option("--connect", is_flag=True, help="Actually connect to the database")
+@click.option("--command", help="MongoDB command to execute (must be valid JavaScript/MongoDB shell command)")
+def main(uri, env_file, verbose, connect, command):
+    """Test MongoDB connection using a URI and optional env file."""
     try:
         # Get connection info in dry-run mode if not connecting
-        if not args.connect and not args.command:
+        if not connect and not command:
             get_mongo_client(
-                mongo_uri=args.uri,
-                env_file=args.env_file,
-                debug=args.verbose,
+                mongo_uri=uri,
+                env_file=env_file,
+                debug=verbose,
                 dry_run=True
             )
             
             # Show minimal connection info without duplicating the output from get_mongo_client
-            if not args.verbose:
+            if not verbose:
                 logger.debug("Connection URI prepared")
             logger.debug("Credential presence determined")
 
@@ -152,27 +150,27 @@ def main():
         else:
             # Actually connect to the database
             client = get_mongo_client(
-                mongo_uri=args.uri,
-                env_file=args.env_file,
-                debug=args.verbose
+                mongo_uri=uri,
+                env_file=env_file,
+                debug=verbose
             )
-            
+
             # Extract database name from URI
-            parsed = uri_parser.parse_uri(args.uri)
+            parsed = uri_parser.parse_uri(uri)
             db_name = parsed.get('database')
-            
+
             if not db_name:
                 raise ValueError("MongoDB URI must include a database name")
-                
+
             db = client[db_name]
-            
-            if args.command:
+
+            if command:
                 # Execute command
-                print(f"Executing command: {args.command}")
-                
+                print(f"Executing command: {command}")
+
                 # Parse MongoDB shell commands directly
                 # Example: db.collection.createIndex({ field: 1 })
-                index_match = re.match(r'db\.(\w+)\.createIndex\((.*)\)', args.command)
+                index_match = re.match(r'db\.(\w+)\.createIndex\((.*)\)', command)
                 
                 if index_match:
                     collection_name = index_match.group(1)
@@ -229,13 +227,13 @@ def main():
                         print("Attempting to execute command with mongosh...")
                         
                         # Get the URI with credentials if any
-                        final_uri = args.uri
+                        final_uri = uri
                         credentials_text = ""
                         if "@" in final_uri:
                             credentials_text = " (with credentials)"
-                        
+
                         # Run the command with mongosh
-                        cmd = ["mongosh", final_uri, "--eval", args.command]
+                        cmd = ["mongosh", final_uri, "--eval", command]
                         result = subprocess.run(cmd, capture_output=True, text=True)
                         
                         if result.returncode == 0:

--- a/external_metadata_awareness/new_expand_envo_po_lexical_index.py
+++ b/external_metadata_awareness/new_expand_envo_po_lexical_index.py
@@ -16,6 +16,8 @@ Requirements:
 """
 
 import re
+
+import click
 from oaklib import get_adapter
 from oaklib.datamodels.lexical_index import (
     LexicalIndex,
@@ -239,10 +241,18 @@ def create_punctuation_insensitive_index(oi):
     return lexical_index
 
 
-def main():
+@click.command()
+@click.option("--envo-adapter", "envo_adapter_string", default=ENVO_ADAPTER_STRING,
+              show_default=True, help="oaklib adapter string for ENVO.")
+@click.option("--po-adapter", "po_adapter_string", default=PO_ADAPTER_STRING,
+              show_default=True, help="oaklib adapter string for PO.")
+@click.option("--output", "output_file", default="expanded_envo_po_lexical_index.yaml",
+              show_default=True, help="Path of the merged lexical index YAML to write.")
+def main(envo_adapter_string, po_adapter_string, output_file):
+    """Combine punctuation-insensitive ENVO and PO lexical indices into one YAML."""
     # Obtain ontology adapters.
-    envo_adapter = get_adapter(ENVO_ADAPTER_STRING)
-    po_adapter = get_adapter(PO_ADAPTER_STRING)
+    envo_adapter = get_adapter(envo_adapter_string)
+    po_adapter = get_adapter(po_adapter_string)
 
     # Create punctuation-insensitive lexical indices for each ontology.
     print("Creating ENVO punctuation-insensitive index...")
@@ -262,7 +272,6 @@ def main():
         merged_index = merge_lexical_indexes(envo_index, po_index, validate_pipelines=False)
 
     # Save the merged lexical index to a YAML file.
-    output_file = "expanded_envo_po_lexical_index.yaml"
     save_lexical_index(merged_index, output_file)
     print(f"Merged lexical index saved to {output_file}")
 

--- a/external_metadata_awareness/plot_oak_annotation_coverage.py
+++ b/external_metadata_awareness/plot_oak_annotation_coverage.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Script to plot the distribution of combined_oak_envo_coverage values
-from the env_triad_component_labels collection for documents with
-combined_oak_envo_coverage > 0.001.
+from the env_triad_component_labels collection for documents above a
+configurable coverage threshold.
 """
 
 import click

--- a/external_metadata_awareness/plot_oak_annotation_coverage.py
+++ b/external_metadata_awareness/plot_oak_annotation_coverage.py
@@ -5,29 +5,36 @@ from the env_triad_component_labels collection for documents with
 combined_oak_envo_coverage > 0.001.
 """
 
+import click
 from pymongo import MongoClient
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import gaussian_kde
 
 
-def main():
-    # MongoDB connection configuration.
-    mongo_url = "mongodb://localhost:27017"
-    client = MongoClient(mongo_url)
-    db = client.ncbi_metadata
+@click.command()
+@click.option("--mongo-uri", default="mongodb://localhost:27017", show_default=True,
+              help="MongoDB connection URI.")
+@click.option("--db-name", default="ncbi_metadata", show_default=True,
+              help="Database holding the env_triad_component_labels collection.")
+@click.option("--threshold", default=0.001, show_default=True, type=float,
+              help="Minimum combined_oak_envo_coverage to include.")
+def main(mongo_uri, db_name, threshold):
+    """Plot the distribution of combined_oak_envo_coverage above a threshold."""
+    client = MongoClient(mongo_uri)
+    db = client[db_name]
     collection = db.env_triad_component_labels
 
-    # Query for documents with combined_oak_envo_coverage > 0.001.
+    # Query for documents above the coverage threshold.
     cursor = collection.find(
-        {"combined_oak_envo_coverage": {"$gt": 0.001}},
+        {"combined_oak_envo_coverage": {"$gt": threshold}},
         {"combined_oak_envo_coverage": 1, "_id": 0}
     )
     # Extract the coverage values.
     values = [doc["combined_oak_envo_coverage"] for doc in cursor if "combined_oak_envo_coverage" in doc]
 
     if not values:
-        print("No documents found with combined_oak_envo_coverage > 0.001")
+        print(f"No documents found with combined_oak_envo_coverage > {threshold}")
         return
 
     # Create a histogram.
@@ -41,7 +48,7 @@ def main():
 
     plt.xlabel("Combined ENVO Coverage")
     plt.ylabel("Density")
-    plt.title("Distribution of combined_oak_envo_coverage (values > 0.001)")
+    plt.title(f"Distribution of combined_oak_envo_coverage (values > {threshold})")
     plt.legend()
     plt.show()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,12 @@ analyze-nmdc-biosample-coverage = 'external_metadata_awareness.analyze_nmdc_bios
 extract-nmdc-doi-inventory = 'external_metadata_awareness.extract_nmdc_doi_inventory:extract_nmdc_doi_inventory'
 mixs-required-slot-report = 'external_metadata_awareness.mixs_required_slot_report:main'
 
+# Cache, plotting, and lexical-index tools (converted to click)
+combine-cache-files = 'external_metadata_awareness.combine_cache_files:main'
+plot-oak-annotation-coverage = 'external_metadata_awareness.plot_oak_annotation_coverage:main'
+expand-envo-po-lexical-index = 'external_metadata_awareness.new_expand_envo_po_lexical_index:main'
+nmdc-collection-stats = 'external_metadata_awareness.adhoc.nmdc_collection_stats:main'
+
 [tool.deptry.per_rule_ignores]
 DEP001 = ["common", "core"] # locally defined
 DEP002 = [

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -6,11 +6,11 @@ MongoDB or network access:
 - Every entry-point target must import and expose its referenced function.
   This catches dead entries (a renamed/deleted module) and any import-time
   breakage from a dependency bump.
-- For click-based entry points, ``--help`` must exit 0 (via click's CliRunner,
-  which does not run the command body, so nothing connects or hangs).
-
-Entry points that are not click commands (e.g. argparse-based) are still
-covered by the load test; their ``--help`` is just not exercised here.
+- Every entry point must be a click command whose ``--help`` exits 0 (via
+  click's CliRunner, which does not run the command body, so nothing connects
+  or hangs). All console_scripts in this project use click; the test enforces
+  that convention so a new argparse- or bare-``sys.argv``-based entry point
+  fails here instead of silently diverging.
 """
 
 import importlib
@@ -70,10 +70,12 @@ def test_entry_point_loads(name, target):
 
 @pytest.mark.parametrize("name,target", _ENTRY_POINTS, ids=_IDS)
 def test_click_entry_point_help(name, target):
-    """click-based entry points respond to --help with exit code 0."""
+    """Every entry point is a click command whose --help exits 0."""
     module_path, _, func_name = target.partition(":")
     obj = getattr(importlib.import_module(module_path), func_name)
-    if not isinstance(obj, click.BaseCommand):
-        pytest.skip(f"{name} is not a click command")
+    assert isinstance(obj, click.BaseCommand), (
+        f"{name} ({target}) is not a click command; all console_scripts in this "
+        "project use click."
+    )
     result = CliRunner().invoke(obj, ["--help"])
     assert result.exit_code == 0, f"{name} --help exited {result.exit_code}:\n{result.output}"


### PR DESCRIPTION
All console_scripts now use click. Previously `mongo-connect` (mongodb_connection.py) used argparse, and four scripts ran via a bare `__main__` block with hardcoded values.

Changes:
- mongodb_connection.py: argparse to click, same five options.
- combine_cache_files, plot_oak_annotation_coverage, new_expand_envo_po_lexical_index, adhoc/nmdc_collection_stats: each `main()` wrapped in a click command. Values that were hardcoded become options whose defaults match the prior behavior, so a no-argument run behaves as before. Each is registered as a console_script.
- tests/test_entry_points.py: now asserts every entry point is a click command rather than skipping non-click ones, so a future argparse- or sys.argv-based entry point fails the smoke test.

Local checks: `pytest tests/test_entry_points.py` passes (70 tests, including the 4 new entry points), `ruff check` clean, `poetry check` shows only pre-existing deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)