### PR TITLE
Document biosample-to-bioproject linkage across the three link collections

### DIFF
--- a/docs/collection-structure-reference.md
+++ b/docs/collection-structure-reference.md
@@ -34,7 +34,7 @@ Last verified: 2026-05-18 (56.3M biosamples, 1.07M bioprojects).
 | `biosamples_flattened` | **Flat** | 56.3M | **Yes** — 40 possible fields, many null per doc | accession, id, submission_date, last_update, publication_date, access, package_content, model_content, status_status, status_when, is_reference, curation_date, curation_status, owner_abbreviation, owner_name, owner_url, description_title, organism_name, taxonomy_id, taxonomy_name, description_comment, plus attribute fields (collection_date, geo_loc_name, env_broad_scale, env_local_scale, env_medium, host, etc.). `model_content` is pipe-joined when a biosample claims conformance to multiple model templates (~5% of docs). |
 | `biosamples_attributes` | **Flat** | 756M | **Yes** — `harmonized_name`, `display_name`, `unit` not always present | biosample_id, accession, attribute_name, content, [harmonized_name], [display_name], [unit] |
 | `biosamples_ids` | **Flat** | 128M | Minimal | biosample_id, accession, db, db_label, id_value |
-| `biosamples_links` | **Flat** | 30.6M | Minimal | biosample_id, accession, type, label, target |
+| `biosamples_links` | **Flat** | 30.6M | Minimal | accession, content (the link value), type (`entrez` or `url`), label, target (present only on `entrez`-type links) |
 | `bioprojects_flattened` | **Flat** | 1M | No | 17 fields |
 
 ### Stage 4: NCBI Schema

--- a/docs/collection-structure-reference.md
+++ b/docs/collection-structure-reference.md
@@ -149,6 +149,28 @@ The current collection (354 docs) operates on `measurement_results_skip_filtered
 
 ---
 
+## Biosample-to-bioproject linkage across sources
+
+Three collections link biosamples to bioprojects, with different scope and shape:
+
+- `sra_biosamples_bioprojects` (Stage 2): the widest coverage (~34M pairs), flat
+  `biosample_accession` / `bioproject_accession`. Prefer this for broad joins.
+- `biosamples_links` (Stage 3): per-biosample links parsed from the BioSample
+  XML. The link value is in `content`, and `type` distinguishes two shapes:
+  - `type: "entrez"` with `target: "bioproject"` means `content` is the numeric
+    Entrez project ID (e.g. `19655`).
+  - `type: "url"` with `label: "BioProject"` means `content` is a BioProject URL,
+    which usually needs parsing rather than a clean join.
+- `bioprojects_flattened` (Stage 3): one row per bioproject carrying both
+  `project_id` (numeric Entrez) and `accession` (e.g. `PRJNA...`), so it bridges
+  the numeric IDs in `biosamples_links` and the accessions used elsewhere.
+
+To resolve a numeric bioproject ID to its accession, join
+`biosamples_links.content` (where `type = "entrez"` and `target = "bioproject"`)
+to `bioprojects_flattened.project_id`.
+
+---
+
 ## Summary
 
 - **Naming convention**: Collections with `_flattened` in the name are always flat. But many flat collections don't have `_flattened` in the name.


### PR DESCRIPTION
Adds a "Biosample-to-bioproject linkage across sources" section to `docs/collection-structure-reference.md`, documenting how the three link collections relate:

- `sra_biosamples_bioprojects` has the widest coverage (~34M pairs).
- `biosamples_links` stores the value in `content`; `type: "entrez"` (with `target: "bioproject"`) gives the numeric Entrez project ID, `type: "url"` gives a URL.
- `bioprojects_flattened` bridges `project_id` (numeric) and `accession` (`PRJ...`).
- Join recipe for numeric→accession resolution.

Field semantics were verified against the live M5 collections (not just prior notes).

Aside for a separate look (not changed here to keep this scoped): the Stage 3 table lists `biosamples_links` fields as `biosample_id, ..., target` but the live collection uses `accession` and `content` (and `target` only on entrez-type links). Worth reconciling in a follow-up.

Docs-only.
