### PR TITLE
Remove duplicate os import in nmdc-submissions-to-mongo.py

### DIFF
--- a/external_metadata_awareness/nmdc-submissions-to-mongo.py
+++ b/external_metadata_awareness/nmdc-submissions-to-mongo.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import re
-import os
 import csv
 import json
 import click


### PR DESCRIPTION
`import os` appears twice at the top of `external_metadata_awareness/nmdc-submissions-to-mongo.py` (introduced during the import cleanup in https://github.com/microbiomedata/external-metadata-awareness/pull/506). This drops the redundant line.

This is the only net change that https://github.com/microbiomedata/external-metadata-awareness/pull/508 would have added over main; the rest of that PR was superseded by https://github.com/microbiomedata/external-metadata-awareness/pull/497 and https://github.com/microbiomedata/external-metadata-awareness/pull/506, so #508 is being closed.