### PR TITLE
Guard non-string CTV values and use a set for obsolete-term lookups

### DIFF
--- a/external_metadata_awareness/nmdc-submissions-to-mongo.py
+++ b/external_metadata_awareness/nmdc-submissions-to-mongo.py
@@ -284,7 +284,7 @@ def process_submissions(mongo_url, output_file):
     ontology_list = ["envo", "pato", "uberon", "po"]
     ontology_adapters = build_ontology_adapters(ontology_list)
     label_cache = load_ontology_labels(ontology_adapters)
-    obsolete_terms_list = find_obsolete_terms(ontology_adapters)
+    obsolete_terms_set = set(find_obsolete_terms(ontology_adapters))
 
     # Connect to MongoDB
     with MongoClient(mongo_url) as client:
@@ -313,7 +313,7 @@ def process_submissions(mongo_url, output_file):
                             if not isinstance(sample, dict):
                                 continue
                             for k, v in list(sample.items()):
-                                if k in ctv_using_slots:
+                                if k in ctv_using_slots and isinstance(v, str):
                                     parsed = parse_label_curie(v)
                                     if parsed:
                                         sample[f"{k}_id"] = parsed['curie']
@@ -333,7 +333,7 @@ def process_submissions(mongo_url, output_file):
                 if key in sample:
                     if sample[key] in label_cache:
                         sample[f"{key}_canonical_label"] = label_cache[sample[key]]
-                    sample[f"{key}_obsolete"] = (sample[key] in obsolete_terms_list)
+                    sample[f"{key}_obsolete"] = (sample[key] in obsolete_terms_set)
 
         # Process environmental context fields
         environmental_fields = ["env_broad_scale", "env_local_scale", "env_medium"]
@@ -345,7 +345,7 @@ def process_submissions(mongo_url, output_file):
                     sample[f"{field}_parsed_curie"] = parsed["curie"]
                     if parsed["curie"] and parsed["curie"] in label_cache:
                         sample[f"{field}_canonical_label"] = label_cache[parsed["curie"]]
-                    sample[f"{field}_obsolete"] = (parsed["curie"] in obsolete_terms_list)
+                    sample[f"{field}_obsolete"] = (parsed["curie"] in obsolete_terms_set)
                     # Check if parsed label matches canonical label
                     sample[f"{field}_match"] = (parsed["label"] == sample.get(f"{field}_canonical_label"))
 

--- a/tests/test_nmdc_submissions_to_mongo.py
+++ b/tests/test_nmdc_submissions_to_mongo.py
@@ -228,6 +228,113 @@ def test_process_submissions_drops_temp_collection_on_rename_failure(monkeypatch
     assert client.db.dropped == ['flattened_submission_biosamples_tmp_20240102030405006789_4321']
 
 
+def test_ctv_slot_parsing_non_string_and_matching_string(monkeypatch, tmp_path):
+    module = _load_script_module(monkeypatch)
+
+    class FakeSchemaView:
+        def __init__(self, _url):
+            pass
+
+        def usage_index(self):
+            return {
+                'ControlledTermValue': [
+                    types.SimpleNamespace(slot='analysis_type')
+                ]
+            }
+
+    class FixedDateTime:
+        @staticmethod
+        def now(tz=None):
+            return real_datetime(2024, 1, 2, 3, 4, 5, 6789, tzinfo=timezone.utc)
+
+    class FakeTempCollection:
+        def __init__(self):
+            self.inserted = []
+
+        def delete_many(self, _query):
+            return None
+
+        def insert_many(self, docs):
+            self.inserted.extend(docs)
+            return types.SimpleNamespace(inserted_ids=list(range(len(docs))))
+
+        def rename(self, _name, **_kwargs):
+            pass
+
+    class FakeSubmissionsCollection:
+        def count_documents(self, _query):
+            return 1
+
+        def find(self):
+            return [
+                {
+                    'id': 'sub-1',
+                    'created': '2024-01-01',
+                    'date_last_modified': '2024-01-02',
+                    'status': 'submitted',
+                    'metadata_submission': {
+                        'sampleData': {
+                            'soil_data': [
+                                {'analysis_type': None},
+                                {'analysis_type': []},
+                                {'analysis_type': 123},
+                                {'analysis_type': 'label [ENVO:01000229]'},
+                            ]
+                        }
+                    },
+                }
+            ]
+
+    temp_col = FakeTempCollection()
+
+    class FakeDB:
+        def __init__(self):
+            self.submissions = FakeSubmissionsCollection()
+
+        def __getitem__(self, key):
+            if key == 'nmdc_submissions':
+                return self.submissions
+            return temp_col
+
+    class FakeMongoClient:
+        def __init__(self, _url):
+            self.db = FakeDB()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __getitem__(self, _name):
+            return self.db
+
+    monkeypatch.setattr(module, 'SchemaView', FakeSchemaView)
+    monkeypatch.setattr(module, 'build_ontology_adapters', lambda _x: {})
+    monkeypatch.setattr(module, 'load_ontology_labels', lambda _x: {})
+    monkeypatch.setattr(module, 'find_obsolete_terms', lambda _x: [])
+    monkeypatch.setattr(module, 'parse_uri', lambda _u: {'database': 'misc_metadata'})
+    monkeypatch.setattr(module, 'MongoClient', FakeMongoClient)
+    monkeypatch.setattr(module, 'datetime', FixedDateTime)
+    monkeypatch.setattr(module.os, 'getpid', lambda: 1234)
+    monkeypatch.setattr(module, 'tqdm', lambda iterable, **_kwargs: iterable)
+
+    ok = module.process_submissions('mongodb://example/misc_metadata', str(tmp_path / 'out.tsv'))
+    assert ok is True
+
+    inserted = temp_col.inserted
+    assert len(inserted) == 4
+
+    # Non-string values (None, [], 123) must not raise and must not add parsed keys
+    for i in range(3):
+        assert 'analysis_type_id' not in inserted[i]
+        assert 'analysis_type_claimed_label' not in inserted[i]
+
+    # Matching string must populate _id and _claimed_label
+    assert inserted[3].get('analysis_type_id') == 'ENVO:01000229'
+    assert inserted[3].get('analysis_type_claimed_label') == 'label'
+
+
 def test_additional_functions_close_mongo_client(monkeypatch):
     module = _load_script_module(monkeypatch)
 

--- a/tests/test_nmdc_submissions_to_mongo.py
+++ b/tests/test_nmdc_submissions_to_mongo.py
@@ -325,8 +325,10 @@ def test_ctv_slot_parsing_non_string_and_matching_string(monkeypatch, tmp_path):
     inserted = temp_col.inserted
     assert len(inserted) == 4
 
-    # Non-string values (None, [], 123) must not raise and must not add parsed keys
-    for i in range(3):
+    # Non-string values (None, [], 123) must not raise and must not add parsed keys;
+    # the original value must still be present in the inserted document.
+    for i, expected in enumerate([None, '', 123]):
+        assert inserted[i].get('analysis_type') == expected  # [] flattens to ''
         assert 'analysis_type_id' not in inserted[i]
         assert 'analysis_type_claimed_label' not in inserted[i]
 


### PR DESCRIPTION
Addresses code-review findings on `external_metadata_awareness/nmdc-submissions-to-mongo.py`:

- `parse_label_curie` is now called only when the ControlledTermValue value is a `str`, avoiding an `AttributeError` when a value is `None`, numeric, or a list.
- Obsolete-term membership checks use a `set` instead of a list, so the per-sample lookups in the two post-processing loops are O(1).

The duplicate `import os` from the same review was already handled in https://github.com/microbiomedata/external-metadata-awareness/pull/513. The review's `finally`/exception concern is not included on purpose: a `finally` block does not suppress a propagating exception, so a failed `insert_many` still raises and the function does not return `True`.