### PR TITLE
Pin setuptools below 82 so pkg_resources stays available

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8336,4 +8336,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "137ea7320549269e73d911dffd170880b36febcf047ff3b47c9d30fbd6a1a309"
+content-hash = "8601f8811cad4981cad2d3b6723c57442cacdf9d530b5aa1411ff68513234295"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ dateparser = "^1.2.2"
 geopy = "^2.4.1"
 json-tabulate = "^0.1.4"
 nmdc-submission-schema = "^11.17.0"
+# setuptools 82.0.0 removed pkg_resources, which eutils 0.6.0 imports at load time.
+# oaklib requires eutils, so oaklib.selector fails to import without it.
+# eutils 0.6.1 drops the import but requires Python 3.12+, which this project does not.
+# See https://github.com/microbiomedata/external-metadata-awareness/pull/523
+setuptools = "<82"
 
 [tool.poetry.group.dev.dependencies]
 deptry = ">=0.23,<0.26"


### PR DESCRIPTION
setuptools 82.0.0 removed `pkg_resources`. `eutils` 0.6.0 imports it at module load, and `oaklib` requires `eutils`, so any import of `oaklib.selector` dies and `tests/test_env_triad_splitter.py` cannot be collected. That is what broke https://github.com/microbiomedata/external-metadata-awareness/pull/523 (Bump setuptools from 80.9.0 to 83.0.0).

`eutils` 0.6.1 drops the `pkg_resources` import, but declares `requires_python >=3.12`, and this project is `python = "^3.10"` with CI on 3.11. So Poetry cannot select it. Pinning is the small fix; moving the project to 3.12 is the real one, and is a separate decision.

Boundary check: setuptools 81.0.0 still ships `pkg_resources` (verified by unpacking the wheel), so `<82` is correct rather than `<81`, despite what the runtime deprecation warning suggests.

`poetry.lock` changes by one line, the content hash. setuptools stays at 80.9.0.
