### PR TITLE
Fix mongo-connect dry run producing no output and mongosh losing credentials

### DIFF
--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -132,23 +132,32 @@ def main():
     parser.add_argument("--connect", action="store_true", help="Actually connect to the database")
     parser.add_argument("--command", help="MongoDB command to execute (must be valid JavaScript/MongoDB shell command)")
     args = parser.parse_args()
-    
+
+    # Nothing else configures logging, so the debug messages get_mongo_client
+    # emits under debug=True were being discarded and --verbose did nothing.
+    # Configure it here, at the entry point, rather than at import time.
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
     try:
         # Get connection info in dry-run mode if not connecting
         if not args.connect and not args.command:
-            get_mongo_client(
+            connection_info = get_mongo_client(
                 mongo_uri=args.uri,
                 env_file=args.env_file,
                 debug=args.verbose,
                 dry_run=True
             )
-            
-            # Show minimal connection info without duplicating the output from get_mongo_client
-            if not args.verbose:
-                logger.debug("Connection URI prepared")
-            logger.debug("Credential presence determined")
 
-            logger.debug("Sample mongosh command omitted from logs for security")
+            # Report on stdout, not through logger.debug: this is the result the
+            # user asked for, and it has to show up without a --verbose flag.
+            # The URI itself is never printed, since it can carry credentials.
+            credentials = "yes" if connection_info["has_credentials"] else "no"
+            print("Dry run: connection URI prepared, no connection attempted.")
+            print(f"Credentials present in URI: {credentials}")
+            print("Re-run with --connect to open a connection.")
         else:
             # Actually connect to the database
             client = get_mongo_client(
@@ -228,10 +237,18 @@ def main():
                     try:
                         print("Attempting to execute command with mongosh...")
                         
-                        # Get the URI with credentials if any
-                        final_uri = args.uri
+                        # Resolve the same URI the PyMongo client used, so that
+                        # credentials supplied via --env-file reach mongosh too.
+                        # dry_run=True builds the URI without opening a connection.
+                        connection_info = get_mongo_client(
+                            mongo_uri=args.uri,
+                            env_file=args.env_file,
+                            debug=args.verbose,
+                            dry_run=True
+                        )
+                        final_uri = connection_info["uri"]
                         credentials_text = ""
-                        if "@" in final_uri:
+                        if connection_info["has_credentials"]:
                             credentials_text = " (with credentials)"
                         
                         # Run the command with mongosh

--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -117,7 +117,13 @@ def get_mongo_client(
             # Credentials needing percent-encoding produce a URI that only
             # fails once parsed. Raise ValueError like the other URI problems
             # above, so callers get the same handling and format guidance.
-            raise ValueError(f"Invalid MongoDB URI after applying credentials: {exc}")
+            # The parser message is not interpolated: this point is reached
+            # after credentials were applied, so it is kept out of the output.
+            raise ValueError(
+                "Invalid MongoDB URI after applying credentials. Username and "
+                "password must be percent-encoded per RFC 3986; see "
+                "urllib.parse.quote_plus."
+            ) from exc
 
         return {
             "uri": final_uri,

--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -106,25 +106,29 @@ def get_mongo_client(
     if debug:
         logger.debug("Final connection URI prepared")
     
+    # Re-parse now that credentials have been applied. This runs for both the
+    # dry-run and connect paths so they fail the same way; validating only in
+    # the dry run left --connect reporting the raw parser message with none of
+    # the guidance below.
+    try:
+        parsed_final = uri_parser.parse_uri(final_uri)
+    except pymongo.errors.InvalidURI as exc:
+        # Credentials needing percent-encoding produce a URI that only fails
+        # once parsed. Raise ValueError like the other URI problems above, so
+        # callers get the same handling and format guidance. The parser message
+        # is not interpolated: this point is reached after credentials were
+        # applied, so it is kept out of the output.
+        raise ValueError(
+            "Invalid MongoDB URI after applying credentials. Username and "
+            "password must be percent-encoded per RFC 3986; see "
+            "urllib.parse.quote_plus."
+        ) from exc
+
     # For dry runs, return connection info instead of a client
     if dry_run:
         # Ask the URI parser for a username rather than looking for an "@",
         # which also matches option values such as ?appName=user@example.com
         # and would report credentials that are not there.
-        try:
-            parsed_final = uri_parser.parse_uri(final_uri)
-        except pymongo.errors.InvalidURI as exc:
-            # Credentials needing percent-encoding produce a URI that only
-            # fails once parsed. Raise ValueError like the other URI problems
-            # above, so callers get the same handling and format guidance.
-            # The parser message is not interpolated: this point is reached
-            # after credentials were applied, so it is kept out of the output.
-            raise ValueError(
-                "Invalid MongoDB URI after applying credentials. Username and "
-                "password must be percent-encoded per RFC 3986; see "
-                "urllib.parse.quote_plus."
-            ) from exc
-
         return {
             "uri": final_uri,
             "has_credentials": bool(parsed_final.get("username")),

--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -111,9 +111,17 @@ def get_mongo_client(
         # Ask the URI parser for a username rather than looking for an "@",
         # which also matches option values such as ?appName=user@example.com
         # and would report credentials that are not there.
+        try:
+            parsed_final = uri_parser.parse_uri(final_uri)
+        except pymongo.errors.InvalidURI as exc:
+            # Credentials needing percent-encoding produce a URI that only
+            # fails once parsed. Raise ValueError like the other URI problems
+            # above, so callers get the same handling and format guidance.
+            raise ValueError(f"Invalid MongoDB URI after applying credentials: {exc}")
+
         return {
             "uri": final_uri,
-            "has_credentials": bool(uri_parser.parse_uri(final_uri).get("username")),
+            "has_credentials": bool(parsed_final.get("username")),
         }
     
     # Create the MongoDB client
@@ -137,9 +145,13 @@ def main(uri, env_file, verbose, connect, command):
     # Nothing else configures logging, so the debug messages get_mongo_client
     # emits under debug=True were being discarded and --verbose did nothing.
     # Configure it here, at the entry point, rather than at import time.
+    # force=True because basicConfig does nothing when handlers already exist,
+    # which would leave --verbose silent under a test runner or any importer
+    # that configured logging first.
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.WARNING,
         format="%(levelname)s %(name)s: %(message)s",
+        force=True,
     )
 
     try:

--- a/tests/test_mongodb_connection.py
+++ b/tests/test_mongodb_connection.py
@@ -6,6 +6,7 @@ These guard two silent-failure bugs: credentials supplied via --env-file not
 reaching the URI at all, and the dry-run path returning nothing usable.
 """
 
+import logging
 import subprocess
 import types
 
@@ -73,6 +74,50 @@ def test_at_sign_in_option_value_is_not_read_as_credentials():
         dry_run=True,
     )
     assert info["has_credentials"] is False
+
+
+def test_credentials_needing_escaping_raise_value_error(tmp_path, monkeypatch):
+    """A password with reserved characters must surface as ValueError.
+
+    Injecting it produces a URI that only fails when parsed. pymongo raises
+    InvalidURI, which is not a ValueError, so it would skip the caller's
+    URI-format error handling.
+    """
+    for var in ("MONGO_USER", "MONGO_PASSWORD", "MONGO_AUTH_SOURCE"):
+        monkeypatch.delenv(var, raising=False)
+    path = tmp_path / ".env"
+    path.write_text("MONGO_USER=user\nMONGO_PASSWORD=p@ssw0rd\n")
+
+    with pytest.raises(ValueError, match="after applying credentials"):
+        get_mongo_client(mongo_uri=_URI, env_file=str(path), dry_run=True)
+
+
+def test_cli_reports_uri_format_guidance_for_unescaped_credentials(tmp_path, monkeypatch):
+    """The CLI keeps its URI-format guidance for that case."""
+    for var in ("MONGO_USER", "MONGO_PASSWORD", "MONGO_AUTH_SOURCE"):
+        monkeypatch.delenv(var, raising=False)
+    path = tmp_path / ".env"
+    path.write_text("MONGO_USER=user\nMONGO_PASSWORD=p@ssw0rd\n")
+
+    result = CliRunner().invoke(main, ["--uri", _URI, "--env-file", str(path)])
+
+    assert result.exit_code == 1
+    assert "The MongoDB URI must use the format" in result.output
+
+
+def test_verbose_wins_over_preconfigured_logging(env_file):
+    """--verbose must work even when something already configured logging.
+
+    logging.basicConfig is a no-op once handlers exist, so without force=True
+    the flag silently does nothing under a test runner or any importer that
+    configured logging first.
+    """
+    logging.basicConfig(level=logging.WARNING)
+
+    result = CliRunner().invoke(main, ["--uri", _URI, "--env-file", env_file, "--verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger().level == logging.DEBUG
 
 
 def test_dry_run_cli_reports_on_stdout(env_file):

--- a/tests/test_mongodb_connection.py
+++ b/tests/test_mongodb_connection.py
@@ -18,6 +18,23 @@ from external_metadata_awareness.mongodb_connection import get_mongo_client, mai
 _URI = "mongodb://localhost:27017/testdb"
 
 
+@pytest.fixture(autouse=True)
+def restore_root_logger():
+    """Undo the CLI's logging.basicConfig(force=True) after each test.
+
+    main() reconfigures the root logger by design, which would otherwise
+    persist for the rest of the session and make test order matter.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
 @pytest.fixture
 def env_file(tmp_path, monkeypatch):
     """A .env file with credentials, isolated from any ambient MONGO_* vars."""

--- a/tests/test_mongodb_connection.py
+++ b/tests/test_mongodb_connection.py
@@ -1,0 +1,130 @@
+"""Unit tests for MongoDB connection URI resolution.
+
+get_mongo_client(dry_run=True) builds the connection URI without opening a
+connection, so the credential-injection logic can be tested without a server.
+These guard two silent-failure bugs: credentials supplied via --env-file not
+reaching the URI at all, and the dry-run path returning nothing usable.
+"""
+
+import subprocess
+import sys
+import types
+
+import pytest
+
+from external_metadata_awareness import mongodb_connection
+from external_metadata_awareness.mongodb_connection import get_mongo_client
+
+_URI = "mongodb://localhost:27017/testdb"
+
+
+@pytest.fixture
+def env_file(tmp_path, monkeypatch):
+    """A .env file with credentials, isolated from any ambient MONGO_* vars."""
+    for var in ("MONGO_USER", "MONGO_PASSWORD", "MONGO_AUTH_SOURCE"):
+        monkeypatch.delenv(var, raising=False)
+    path = tmp_path / ".env"
+    path.write_text("MONGO_USER=testuser\nMONGO_PASSWORD=testpass\n")
+    return str(path)
+
+
+def test_dry_run_returns_connection_info_without_connecting():
+    info = get_mongo_client(mongo_uri=_URI, dry_run=True)
+    assert info["uri"] == _URI
+    assert info["has_credentials"] is False
+
+
+def test_env_file_credentials_are_injected_into_uri(env_file):
+    """--env-file credentials must reach the URI; mongosh is handed this value."""
+    info = get_mongo_client(mongo_uri=_URI, env_file=env_file, dry_run=True)
+    assert info["has_credentials"] is True
+    assert "testuser" in info["uri"]
+    assert "/testdb" in info["uri"]
+
+
+def test_env_file_credentials_add_auth_source(env_file):
+    """Without authSource, auth is attempted against the URI's own database."""
+    info = get_mongo_client(mongo_uri=_URI, env_file=env_file, dry_run=True)
+    assert "authSource=admin" in info["uri"]
+
+
+def test_existing_uri_credentials_are_replaced(env_file):
+    info = get_mongo_client(
+        mongo_uri="mongodb://olduser:oldpass@localhost:27017/testdb",
+        env_file=env_file,
+        dry_run=True,
+    )
+    assert "olduser" not in info["uri"]
+    assert "testuser" in info["uri"]
+
+
+def test_missing_env_file_is_an_error():
+    with pytest.raises(ValueError, match="not found"):
+        get_mongo_client(mongo_uri=_URI, env_file="/nonexistent/.env", dry_run=True)
+
+
+def test_dry_run_cli_reports_on_stdout(env_file, monkeypatch, capsys):
+    """The dry-run CLI must print something.
+
+    It previously reported only through logger.debug, and nothing configures
+    logging, so `mongo-connect --uri ...` produced no output at all.
+    """
+    monkeypatch.setattr(
+        sys, "argv", ["mongo-connect", "--uri", _URI, "--env-file", env_file]
+    )
+
+    mongodb_connection.main()
+    out = capsys.readouterr().out
+
+    assert out.strip(), "dry-run CLI produced no output"
+    assert "Credentials present in URI: yes" in out
+    assert "testpass" not in out, "the URI must never be printed"
+
+
+def test_mongosh_fallback_receives_env_file_credentials(env_file, monkeypatch, capsys):
+    """The mongosh fallback must be handed the credential-injected URI.
+
+    It previously passed the raw --uri straight through, so --env-file
+    credentials never reached mongosh and auth failed even though the PyMongo
+    client had connected fine. pymongo.MongoClient connects lazily, so no
+    server is needed; only subprocess.run has to be stubbed out.
+    """
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mongo-connect",
+            "--uri", _URI,
+            "--env-file", env_file,
+            "--command", "db.runCommand({ping: 1})",
+        ],
+    )
+
+    mongodb_connection.main()
+    capsys.readouterr()
+
+    assert captured["cmd"][0] == "mongosh"
+    mongosh_uri = captured["cmd"][1]
+    assert "testuser" in mongosh_uri, "credentials from --env-file never reached mongosh"
+    assert "authSource=" in mongosh_uri
+    assert "/testdb" in mongosh_uri
+
+
+@pytest.mark.parametrize(
+    "bad_uri,message",
+    [
+        ("", "required"),
+        ("http://localhost:27017/testdb", "must start with"),
+        ("mongodb://localhost:27017", "database name"),
+    ],
+)
+def test_invalid_uris_are_rejected(bad_uri, message):
+    with pytest.raises(ValueError, match=message):
+        get_mongo_client(mongo_uri=bad_uri, dry_run=True)

--- a/tests/test_mongodb_connection.py
+++ b/tests/test_mongodb_connection.py
@@ -31,6 +31,12 @@ def restore_root_logger():
     try:
         yield
     finally:
+        # Close whatever basicConfig added before dropping it, so the handler
+        # is not left open. Only handlers that appeared during the test are
+        # touched; the originals are put back untouched.
+        for handler in root.handlers:
+            if handler not in saved_handlers:
+                handler.close()
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
 

--- a/tests/test_mongodb_connection.py
+++ b/tests/test_mongodb_connection.py
@@ -109,17 +109,30 @@ def test_credentials_needing_escaping_raise_value_error(tmp_path, monkeypatch):
         get_mongo_client(mongo_uri=_URI, env_file=str(path), dry_run=True)
 
 
-def test_cli_reports_uri_format_guidance_for_unescaped_credentials(tmp_path, monkeypatch):
-    """The CLI keeps its URI-format guidance for that case."""
+@pytest.mark.parametrize("extra_args", [[], ["--connect"]], ids=["dry-run", "connect"])
+def test_cli_reports_uri_format_guidance_for_unescaped_credentials(
+    tmp_path, monkeypatch, extra_args
+):
+    """Both paths report unescaped credentials the same way.
+
+    Validating only in the dry-run branch left --connect surfacing pymongo's
+    raw message with none of the guidance.
+    """
     for var in ("MONGO_USER", "MONGO_PASSWORD", "MONGO_AUTH_SOURCE"):
         monkeypatch.delenv(var, raising=False)
     path = tmp_path / ".env"
     path.write_text("MONGO_USER=user\nMONGO_PASSWORD=p@ssw0rd\n")
 
-    result = CliRunner().invoke(main, ["--uri", _URI, "--env-file", str(path)])
+    result = CliRunner().invoke(
+        main, ["--uri", _URI, "--env-file", str(path)] + extra_args
+    )
 
     assert result.exit_code == 1
+    assert "must be percent-encoded per RFC 3986" in result.output
     assert "The MongoDB URI must use the format" in result.output
+    assert "escaped according to RFC 3986" not in result.output, (
+        "pymongo's raw parser message leaked into the output"
+    )
 
 
 def test_verbose_wins_over_preconfigured_logging(env_file):


### PR DESCRIPTION
Fixes two bugs Copilot raised on https://github.com/microbiomedata/external-metadata-awareness/pull/500. Both predate that PR, which only renamed `args.uri` to `uri` while converting the CLI to click, so they are fixed here against main instead of widening its scope.

**mongosh never got the credentials.** The fallback set `final_uri = args.uri`, the raw command-line value, so credentials loaded from `--env-file` never reached mongosh. The PyMongo client authenticated fine while mongosh failed, making `--env-file` look broken on that one path only. It now resolves the URI through the existing `dry_run=True` call, which builds the credential-injected URI (including `authSource`) without opening a connection.

**The dry run printed nothing.** It discarded `get_mongo_client`'s return value and reported through `logger.debug` only. Nothing in the codebase configures logging, so those records went nowhere and `mongo-connect --uri ...` produced no output whatsoever, with `--verbose` appearing to do nothing. It now prints to stdout, and `main` configures logging at the entry point so `--verbose` works. The URI itself is still never printed, matching the existing choice not to log it even redacted.

Adds `tests/test_mongodb_connection.py`, 10 tests. `get_mongo_client(dry_run=True)` builds the URI without connecting and pymongo connects lazily, so no server is needed; only `subprocess.run` is stubbed. The two tests covering these paths were checked against the unfixed code and fail there:

```
FAILED test_dry_run_cli_reports_on_stdout
FAILED test_mongosh_fallback_receives_env_file_credentials - AssertionError:
  credentials from --env-file never reached mongosh
  assert 'testuser' in 'mongodb://localhost:27017/testdb'
```

One thing to flag rather than fix quietly: propagating credentials means the URI now reaches `mongosh` as a process argument, so it is visible in `ps` while the command runs. The previous behavior only avoided that by being broken, and a URI passed directly via `--uri` was always exposed this way. Getting credentials to mongosh without argv exposure needs a different mechanism and is worth its own issue.
