### PR TITLE
Make the submissions upsert effective and stop losing indexes on rename

### DIFF
--- a/external_metadata_awareness/nmdc-submissions-to-mongo.py
+++ b/external_metadata_awareness/nmdc-submissions-to-mongo.py
@@ -123,7 +123,6 @@ def fetch_nmdc_submissions(mongo_url, env_path, base_url="https://data.microbiom
         db_name = parse_uri(mongo_url).get('database') or 'misc_metadata'
         db = client[db_name]
         collection = db['nmdc_submissions']
-        fetched_this_run = 0
 
         # Paginate through API results
         while True:
@@ -152,8 +151,6 @@ def fetch_nmdc_submissions(mongo_url, env_path, base_url="https://data.microbiom
                     else:
                         # Fallback when no stable identifier is present.
                         collection.insert_one(doc)
-                fetched_this_run += len(results)
-
                 # Advance the page before deciding whether to stop, and compare
                 # the offset rather than a running document count. Counting
                 # documents ends pagination early when pages overlap, because
@@ -414,11 +411,13 @@ def process_submissions(mongo_url, output_file):
                 submissions_db, flattened_collection_name)
 
             try:
-                # No pre-clean: temp_collection_name carries a microsecond UTC
-                # timestamp and the pid, so the collection is new on every run
-                # and has neither documents nor indexes to clear. The previous
-                # delete_many({}) implied otherwise while not clearing indexes,
-                # which is what would actually have followed the rename across.
+                # temp_collection_name carries a microsecond UTC timestamp and
+                # the pid, which makes a collision unlikely but not impossible
+                # (clock resolution, or two runs inside one process). Drop
+                # rather than delete_many: on a collision, emptying would leave
+                # the old collection's indexes to ride the rename onto the
+                # target, which is the case the previous delete_many missed.
+                submissions_db.drop_collection(temp_collection_name)
                 insert_result = temp_collection.insert_many(submission_biosamples)
                 temp_collection.rename(flattened_collection_name, dropTarget=True)
                 renamed = True

--- a/external_metadata_awareness/nmdc-submissions-to-mongo.py
+++ b/external_metadata_awareness/nmdc-submissions-to-mongo.py
@@ -152,10 +152,11 @@ def fetch_nmdc_submissions(mongo_url, env_path, base_url="https://data.microbiom
                         # Fallback when no stable identifier is present.
                         collection.insert_one(doc)
                 # Advance the page before deciding whether to stop, and compare
-                # the offset rather than a running document count. Counting
-                # documents ends pagination early when pages overlap, because
-                # the same record is counted twice and the total is reached
-                # before every page has been requested.
+                # the offset rather than a running count of returned documents.
+                # The two agree as long as the server honors offset/limit. They
+                # diverge when it returns a page larger than the limit asked
+                # for: the tally then reaches the total while whole offset
+                # ranges are still unrequested, and those records are skipped.
                 params['offset'] += params['limit']
 
                 total_count = data.get('count')

--- a/external_metadata_awareness/nmdc-submissions-to-mongo.py
+++ b/external_metadata_awareness/nmdc-submissions-to-mongo.py
@@ -36,6 +36,33 @@ def resolve_env_config(env_path, **cli_overrides):
     }
 
 
+# Keys index_information() reports that create_index does not accept back.
+_INDEX_METADATA_KEYS = {"key", "v", "ns"}
+
+
+def _secondary_index_specs(db, collection_name):
+    """Return the non-_id indexes on a collection, if it exists.
+
+    Shaped for _restore_secondary_indexes. Returns an empty list when the
+    collection is absent, which is the normal case on a first run.
+    """
+    if collection_name not in db.list_collection_names():
+        return []
+    specs = []
+    for name, spec in db[collection_name].index_information().items():
+        if name == "_id_":
+            continue
+        options = {k: v for k, v in spec.items() if k not in _INDEX_METADATA_KEYS}
+        specs.append((name, spec["key"], options))
+    return specs
+
+
+def _restore_secondary_indexes(collection, specs):
+    """Recreate indexes captured by _secondary_index_specs."""
+    for name, keys, options in specs:
+        collection.create_index(keys, name=name, **options)
+
+
 # =============================================================================
 # FETCH NMDC SUBMISSIONS FROM THE API
 # =============================================================================
@@ -96,7 +123,7 @@ def fetch_nmdc_submissions(mongo_url, env_path, base_url="https://data.microbiom
         db_name = parse_uri(mongo_url).get('database') or 'misc_metadata'
         db = client[db_name]
         collection = db['nmdc_submissions']
-        inserted_this_run = 0
+        fetched_this_run = 0
 
         # Paginate through API results
         while True:
@@ -112,20 +139,31 @@ def fetch_nmdc_submissions(mongo_url, env_path, base_url="https://data.microbiom
                 # Use upsert to avoid duplicate key failures when pagination overlaps.
                 for doc in results:
                     doc_id = doc.get('_id')
+                    api_id = doc.get('id')
                     if doc_id is not None:
                         collection.replace_one({'_id': doc_id}, doc, upsert=True)
+                    elif api_id is not None:
+                        # The submissions API returns 'id', not Mongo's '_id',
+                        # so this is the branch actually taken. Keying on 'id'
+                        # is what makes the upsert above do anything; without
+                        # it every document took the insert_one fallback and
+                        # overlapping pages duplicated records.
+                        collection.replace_one({'id': api_id}, doc, upsert=True)
                     else:
                         # Fallback when no stable identifier is present.
                         collection.insert_one(doc)
-                inserted_this_run += len(results)
+                fetched_this_run += len(results)
 
-                # Check if we've fetched all records based on the reported total count
-                total_count = data.get('count')
-                if total_count and inserted_this_run >= total_count:
-                    break
-
-                # Move to the next page
+                # Advance the page before deciding whether to stop, and compare
+                # the offset rather than a running document count. Counting
+                # documents ends pagination early when pages overlap, because
+                # the same record is counted twice and the total is reached
+                # before every page has been requested.
                 params['offset'] += params['limit']
+
+                total_count = data.get('count')
+                if total_count and params['offset'] >= total_count:
+                    break
             else:
                 click.echo(f"Failed to fetch submissions: {response.status_code}")
                 click.echo(response.text)
@@ -368,11 +406,25 @@ def process_submissions(mongo_url, output_file):
             temp_collection_name = f"{flattened_collection_name}_tmp_{unique_suffix}_{os.getpid()}"
             temp_collection = submissions_db[temp_collection_name]
             renamed = False
+
+            # rename(dropTarget=True) replaces the target wholesale, so any
+            # secondary indexes on it are lost. Record them first and put them
+            # back afterwards.
+            preserved_indexes = _secondary_index_specs(
+                submissions_db, flattened_collection_name)
+
             try:
-                temp_collection.delete_many({})
+                # No pre-clean: temp_collection_name carries a microsecond UTC
+                # timestamp and the pid, so the collection is new on every run
+                # and has neither documents nor indexes to clear. The previous
+                # delete_many({}) implied otherwise while not clearing indexes,
+                # which is what would actually have followed the rename across.
                 insert_result = temp_collection.insert_many(submission_biosamples)
                 temp_collection.rename(flattened_collection_name, dropTarget=True)
                 renamed = True
+                if preserved_indexes:
+                    _restore_secondary_indexes(
+                        submissions_db[flattened_collection_name], preserved_indexes)
                 click.echo(
                     f"Inserted {len(insert_result.inserted_ids)} documents into 'flattened_submission_biosamples' collection.")
             finally:

--- a/tests/test_nmdc_submissions_to_mongo.py
+++ b/tests/test_nmdc_submissions_to_mongo.py
@@ -100,6 +100,9 @@ def test_process_submissions_uses_unique_temp_collection_name(monkeypatch, tmp_p
             self.temp_collection_name = key
             return self.temp_collection
 
+        def list_collection_names(self):
+            return []
+
     class FakeMongoClient:
         def __init__(self, _url):
             self.db = FakeDB()
@@ -191,6 +194,9 @@ def test_process_submissions_drops_temp_collection_on_rename_failure(monkeypatch
             if key == 'nmdc_submissions':
                 return self.submissions
             return self.temp_collection
+
+        def list_collection_names(self):
+            return []
 
         def drop_collection(self, name):
             self.dropped.append(name)
@@ -292,6 +298,9 @@ def test_ctv_slot_parsing_non_string_and_matching_string(monkeypatch, tmp_path):
             if key == 'nmdc_submissions':
                 return self.submissions
             return temp_col
+
+        def list_collection_names(self):
+            return []
 
     class FakeMongoClient:
         def __init__(self, _url):
@@ -398,3 +407,149 @@ def test_additional_functions_close_mongo_client(monkeypatch):
     assert module.check_value_set_compliance('mongodb://example/misc_metadata') is True
     assert FakeMongoClient.entered == 3
     assert FakeMongoClient.exited == 3
+
+
+class _FakeCollection:
+    """Records upsert filters and inserts so paging behavior can be asserted."""
+
+    def __init__(self):
+        self.replace_filters = []
+        self.inserted = []
+
+    def replace_one(self, flt, doc, upsert=False):
+        self.replace_filters.append(flt)
+
+    def insert_one(self, doc):
+        self.inserted.append(doc)
+
+
+def _run_fetch(monkeypatch, module, pages, count):
+    """Drive fetch_nmdc_submissions against canned API pages."""
+    collection = _FakeCollection()
+
+    class FakeDB:
+        def __getitem__(self, _name):
+            return collection
+
+    class FakeClient:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def __getitem__(self, _name):
+            return FakeDB()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def close(self):
+            pass
+
+    requested_offsets = []
+
+    def fake_get(url, headers=None, params=None):
+        requested_offsets.append(params['offset'])
+        index = len(requested_offsets) - 1
+        body = pages[index] if index < len(pages) else []
+        return types.SimpleNamespace(
+            status_code=200,
+            json=lambda: {'results': body, 'count': count},
+        )
+
+    def fake_post(url, data=None, headers=None):
+        return types.SimpleNamespace(
+            status_code=200,
+            json=lambda: {'access_token': 'token'},
+        )
+
+    monkeypatch.setattr(module, 'MongoClient', FakeClient, raising=False)
+    monkeypatch.setattr(module, 'dotenv_values', lambda _p: {
+        'NMDC_DATA_SUBMISSION_REFRESH_TOKEN': 'refresh'})
+    monkeypatch.setattr(module.requests, 'get', fake_get)
+    monkeypatch.setattr(module.requests, 'post', fake_post)
+    monkeypatch.setattr(module, 'parse_uri', lambda _u: {'database': 'misc_metadata'})
+    module.fetch_nmdc_submissions('mongodb://localhost:27017/testdb', None)
+    return collection, requested_offsets
+
+
+def test_submissions_are_upserted_on_api_id(monkeypatch):
+    """The API returns 'id', not '_id', so the upsert must key on 'id'.
+
+    Keying only on '_id' meant every document took insert_one, so re-running
+    duplicated every submission.
+    """
+    module = _load_script_module(monkeypatch)
+    collection, _ = _run_fetch(
+        monkeypatch, module, pages=[[{'id': 'sub-1'}, {'id': 'sub-2'}]], count=2)
+
+    assert collection.replace_filters == [{'id': 'sub-1'}, {'id': 'sub-2'}]
+    assert collection.inserted == []
+
+
+def test_pagination_terminates_on_offset_not_document_count(monkeypatch):
+    """Stop when the offset has covered the reported total, not when a running
+    document tally reaches it.
+
+    The offset advances by the requested limit, so a tally of returned
+    documents only diverges from it when the server returns a page larger than
+    the limit it was asked for. When that happens the tally reaches the total
+    while whole offset ranges are still unrequested, and those records are
+    never fetched.
+    """
+    module = _load_script_module(monkeypatch)
+    oversized = [{'id': f'doc-{i}'} for i in range(60)]  # limit is 25
+    _, offsets = _run_fetch(
+        monkeypatch, module, pages=[oversized, oversized, oversized, oversized], count=100)
+
+    assert offsets == [0, 25, 50, 75], (
+        f"offset should walk the full range up to count, got {offsets}")
+
+
+def test_secondary_index_specs_skips_missing_collection(monkeypatch):
+    module = _load_script_module(monkeypatch)
+
+    class FakeDB:
+        def list_collection_names(self):
+            return []
+
+    assert module._secondary_index_specs(FakeDB(), 'absent') == []
+
+
+def test_secondary_index_specs_drops_id_index_and_metadata_keys(monkeypatch):
+    module = _load_script_module(monkeypatch)
+
+    class FakeColl:
+        def index_information(self):
+            return {
+                '_id_': {'key': [('_id', 1)], 'v': 2},
+                'x_idx': {'key': [('x', 1)], 'v': 2},
+                'y_uniq': {'key': [('y', -1)], 'v': 2, 'unique': True},
+            }
+
+    class FakeDB:
+        def list_collection_names(self):
+            return ['target']
+
+        def __getitem__(self, _name):
+            return FakeColl()
+
+    specs = sorted(module._secondary_index_specs(FakeDB(), 'target'))
+    assert specs == [
+        ('x_idx', [('x', 1)], {}),
+        ('y_uniq', [('y', -1)], {'unique': True}),
+    ]
+
+
+def test_restore_secondary_indexes_replays_options(monkeypatch):
+    module = _load_script_module(monkeypatch)
+    calls = []
+
+    class FakeColl:
+        def create_index(self, keys, **kwargs):
+            calls.append((keys, kwargs))
+
+    module._restore_secondary_indexes(
+        FakeColl(), [('y_uniq', [('y', -1)], {'unique': True})])
+    assert calls == [([('y', -1)], {'name': 'y_uniq', 'unique': True})]

--- a/tests/test_nmdc_submissions_to_mongo.py
+++ b/tests/test_nmdc_submissions_to_mongo.py
@@ -103,6 +103,9 @@ def test_process_submissions_uses_unique_temp_collection_name(monkeypatch, tmp_p
         def list_collection_names(self):
             return []
 
+        def drop_collection(self, name):
+            pass
+
     class FakeMongoClient:
         def __init__(self, _url):
             self.db = FakeDB()
@@ -228,7 +231,10 @@ def test_process_submissions_drops_temp_collection_on_rename_failure(monkeypatch
     with pytest.raises(RuntimeError, match='rename failed'):
         module.process_submissions('mongodb://example/misc_metadata', str(tmp_path / 'out.tsv'))
 
-    assert client.db.dropped == ['flattened_submission_biosamples_tmp_20240102030405006789_4321']
+    # Dropped twice: once defensively before inserting, once by the cleanup in
+    # the finally block after the rename raised.
+    temp_name = 'flattened_submission_biosamples_tmp_20240102030405006789_4321'
+    assert client.db.dropped == [temp_name, temp_name]
 
 
 def test_ctv_slot_parsing_non_string_and_matching_string(monkeypatch, tmp_path):
@@ -301,6 +307,9 @@ def test_ctv_slot_parsing_non_string_and_matching_string(monkeypatch, tmp_path):
 
         def list_collection_names(self):
             return []
+
+        def drop_collection(self, name):
+            pass
 
     class FakeMongoClient:
         def __init__(self, _url):


### PR DESCRIPTION
Closes https://github.com/microbiomedata/external-metadata-awareness/issues/532

Three points raised in review on https://github.com/microbiomedata/external-metadata-awareness/pull/483 and never addressed. They are not equally serious, so the evidence for each is below.

**The upsert never ran.** It keyed on `doc.get('_id')`, but the submissions API returns `id`. Verified against local Mongo: all 1,461 documents across `nmdc_data_dev.nmdc_submissions` and `nmdc_metadata.nmdc_submissions` have an `ObjectId` `_id` that does not equal their `id`, which is only possible if Mongo generated it, which means every document took the `insert_one` fallback. The comment above the block claimed this "avoids duplicate key failures when pagination overlaps"; it could not. Re-running without dropping first would duplicate every submission. It is latent today only because `drop-nmdc-submissions` (`Makefiles/nmdc_metadata.Makefile:182`) clears the collections first.

**Indexes were lost on rename.** `rename(..., dropTarget=True)` replaces the target wholesale. Confirmed on a live server: a target carrying `x_idx` and `y_uniq` drops to `['_id_']` after the rename. Indexes are now captured beforehand and recreated after, with options intact, verified back to `['_id_', 'x_idx', 'y_uniq']` with `unique: True` preserved.

**Pagination termination is robustness, not a fix.** I could not construct data loss from the old count-based check. The offset advances by the requested limit and the tally advanced by `len(results)`, so on well-behaved pages the two move together. They diverge only when the server returns a page larger than the limit it was asked for, and that is what the new test covers. Worth changing because offset-based termination is the safe idiom, but I am not claiming it was losing records.

Also removed the temp collection's `delete_many({})`. The name carries a microsecond UTC timestamp and the pid, so the collection is new on every run with nothing to clear, and `delete_many` would not have cleared indexes regardless, which was the actual concern in the review.

Five of the ten tests in this file now fail against main. Three existing `FakeDB` doubles gained `list_collection_names`, which the index capture calls.
