### PR TITLE
Report annotation errors through click, expand connection failure guidance

### DIFF
--- a/external_metadata_awareness/mixs_required_slot_report.py
+++ b/external_metadata_awareness/mixs_required_slot_report.py
@@ -248,7 +248,8 @@ def connect_mongo(mongo_uri: str, env_file: str | None) -> MongoClient:
     """
     final_uri = mongo_uri
     parsed = urlparse(mongo_uri)
-    if not (parsed.username and parsed.password):
+    uri_has_credentials = bool(parsed.username and parsed.password)
+    if not uri_has_credentials:
         config = {}
         if env_file and Path(env_file).exists():
             config = dotenv_values(env_file)
@@ -287,14 +288,18 @@ def connect_mongo(mongo_uri: str, env_file: str | None) -> MongoClient:
         client.admin.command("ping")
         return client
     except OperationFailure as exc:
-        # Built from MONGO_CRED_KEY_PAIRS so the message cannot drift from the
-        # pairs actually tried. Naming only MONGO_USER/MONGO_PASSWORD misdirects
-        # anyone using the SOURCE_ or NMDC_ pairs.
-        accepted_keys = " or ".join("/".join(pair) for pair in MONGO_CRED_KEY_PAIRS)
+        # Point at whichever source the credentials actually came from. The env
+        # file is not consulted at all when the URI carries its own, so naming
+        # it there sends people to the wrong place. The key pairs are built from
+        # MONGO_CRED_KEY_PAIRS so the message cannot drift from what is tried.
+        if uri_has_credentials:
+            hint = "Check the username and password embedded in the URI"
+        else:
+            accepted_keys = " or ".join("/".join(p) for p in MONGO_CRED_KEY_PAIRS)
+            hint = f"Check the credentials in the --env-file ({accepted_keys})"
         raise click.ClickException(
-            "MongoDB authentication/authorization failed. Check the credentials "
-            f"in the --env-file ({accepted_keys}), and that the user has read "
-            "access to the database named in the URI."
+            f"MongoDB authentication/authorization failed. {hint}, and that the "
+            "user has read access to the database named in the URI."
         ) from exc
     except ConnectionFailure as exc:
         raise click.ClickException(

--- a/external_metadata_awareness/mixs_required_slot_report.py
+++ b/external_metadata_awareness/mixs_required_slot_report.py
@@ -287,10 +287,14 @@ def connect_mongo(mongo_uri: str, env_file: str | None) -> MongoClient:
         client.admin.command("ping")
         return client
     except OperationFailure as exc:
+        # Built from MONGO_CRED_KEY_PAIRS so the message cannot drift from the
+        # pairs actually tried. Naming only MONGO_USER/MONGO_PASSWORD misdirects
+        # anyone using the SOURCE_ or NMDC_ pairs.
+        accepted_keys = " or ".join("/".join(pair) for pair in MONGO_CRED_KEY_PAIRS)
         raise click.ClickException(
-            "MongoDB authentication/authorization failed. Check MONGO_USER and "
-            "MONGO_PASSWORD in the --env-file, and that the user has read access "
-            "to the database named in the URI."
+            "MongoDB authentication/authorization failed. Check the credentials "
+            f"in the --env-file ({accepted_keys}), and that the user has read "
+            "access to the database named in the URI."
         ) from exc
     except ConnectionFailure as exc:
         raise click.ClickException(

--- a/external_metadata_awareness/mixs_required_slot_report.py
+++ b/external_metadata_awareness/mixs_required_slot_report.py
@@ -59,6 +59,15 @@ ENV_PACKAGE_WEIGHT_PIPELINE = [
     {"$group": {"_id": "$env_package.has_raw_value", "n": {"$sum": 1}}}
 ]
 REQUIRED_ANNOTATION_COLUMNS = frozenset({"slot", "priority", "comment"})
+
+
+class AnnotationFormatError(click.ClickException, ValueError):
+    """Raised when the --annotations TSV is missing required columns.
+
+    Subclasses ClickException so the CLI prints a clean "Error: ..." line
+    instead of a traceback, and ValueError so library callers can keep
+    catching it as one.
+    """
 # NMDC materialized schema, matching analyze_nmdc_biosample_coverage.py.
 DEFAULT_NMDC_SCHEMA = (
     "https://raw.githubusercontent.com/microbiomedata/nmdc-schema/"
@@ -278,9 +287,16 @@ def connect_mongo(mongo_uri: str, env_file: str | None) -> MongoClient:
         client.admin.command("ping")
         return client
     except OperationFailure as exc:
-        raise click.ClickException("MongoDB authentication/authorization failed.") from exc
+        raise click.ClickException(
+            "MongoDB authentication/authorization failed. Check MONGO_USER and "
+            "MONGO_PASSWORD in the --env-file, and that the user has read access "
+            "to the database named in the URI."
+        ) from exc
     except ConnectionFailure as exc:
-        raise click.ClickException("Could not reach MongoDB server.") from exc
+        raise click.ClickException(
+            "Could not reach MongoDB server. Check the host and port in the URI, "
+            "and whether an SSH tunnel or VPN is required to reach it."
+        ) from exc
     except PyMongoError as exc:
         raise click.ClickException(f"MongoDB client error: {exc}") from exc
 
@@ -340,7 +356,7 @@ def load_annotations(annotations_path: Path) -> dict[str, tuple[str, str]]:
         if missing_columns:
             present = ", ".join(sorted(present_columns)) if present_columns else "<none>"
             missing = ", ".join(missing_columns)
-            raise ValueError(
+            raise AnnotationFormatError(
                 f"Annotation TSV is missing required columns: {missing}. "
                 f"Present columns: {present}"
             )

--- a/notebooks/studies_exploration/streams_assessments_llm/notes.txt
+++ b/notebooks/studies_exploration/streams_assessments_llm/notes.txt
@@ -5,8 +5,8 @@ Set to Claude 3.5 Sonnet. I have not ever changed the response style setting. I 
 Upload a PDF and "streams_final.tsv" (does the order matter?)
 Paste in claude_3.5_sonnet_prompt_v2.txt and click the submit button
 
-Hasn't ever provide a link for downloading a TSV file.
-Usually puts tab-separated content in the artifact pane to the right with a click to download button. The files obtained form that have almost always had an .md extension, but they have always been tab separated values.
+Hasn't ever provided a link for downloading a TSV file.
+Usually puts tab-separated content in the artifact pane to the right with a click to download button. The files obtained from that have almost always had an .md extension, but they have always been tab separated values.
 Sometimes puts response in chat flow with click to copy button
 Sometimes generates outline-like analysis, either in the artifact pane (instead of TSV) or in the chat flow, in addition to the TSV in the artifact pane
 	The first that time happened, I uploaded a completed TSV output and said to regenerate the output in the same style, without retaining any of the content, but rather extracting new content from the PDF. Don't remember which PDF that was for.


### PR DESCRIPTION
Closes https://github.com/microbiomedata/external-metadata-awareness/issues/533

Review points that were raised and never addressed. Grouped because none justifies its own PR.

**Traceback for a user input error.** The `--annotations` required-column check raised a bare `ValueError`, which click does not handle:

```
exit_code: 1, exception: ValueError
```

It now raises `AnnotationFormatError`, subclassing both `ClickException` and `ValueError`. That is the approach the original review suggested, and it matters here because `tests/test_mixs_required_slot_report.py:241` catches `ValueError`. The CLI now prints:

```
Error: Annotation TSV is missing required columns: comment, priority. Present columns: slot, wrong
```

**Connection errors said what failed, not what to check.** Expanded the auth and connection messages, leading sentences unchanged so the existing exception mapping still reads the same.

**Two typos** in `notebooks/studies_exploration/streams_assessments_llm/notes.txt`: "provide" to "provided", "obtained form" to "obtained from".
