### PR TITLE
Stop the verbose CURIE prints from bypassing the logging policy

### DIFF
--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -210,10 +210,10 @@ def process_document(doc, collection, api_key, verbose=False):
     term_uri = safe_expand(curie)
     if term_uri:
         if verbose:
-            print(f"Expansion success: {curie} -> {term_uri}")
+            logger.debug("CURIE expansion succeeded")
     else:
         if verbose:
-            print(f"Expansion failed for CURIE: {curie}")
+            logger.debug("CURIE expansion failed")
         return
 
     reverse_engineered = converter.compress(term_uri)

--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -250,6 +250,16 @@ def process_document(doc, collection, api_key, verbose=False):
 @click.option('--collection', default='env_triad_component_curies_uc', help='MongoDB collection name')
 @click.option('--verbose', is_flag=True, help='Show verbose connection and processing output')
 def main(mongo_uri, env_file, collection, verbose):
+    # Nothing else configures logging, so every logger.debug guarded by
+    # `if verbose` was being dropped: the root logger defaults to WARNING.
+    # force=True because basicConfig is a no-op once handlers exist, which
+    # would leave --verbose silent under any importer that configured first.
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+        force=True,
+    )
+
     # Load environment variables from .env file
     load_dotenv(env_file)
     

--- a/external_metadata_awareness/new_bioportal_curie_mapper.py
+++ b/external_metadata_awareness/new_bioportal_curie_mapper.py
@@ -254,11 +254,17 @@ def main(mongo_uri, env_file, collection, verbose):
     # `if verbose` was being dropped: the root logger defaults to WARNING.
     # force=True because basicConfig is a no-op once handlers exist, which
     # would leave --verbose silent under any importer that configured first.
+    #
+    # The root stays at WARNING and only this module's logger goes to DEBUG.
+    # Putting the root at DEBUG would switch on urllib3 and requests_cache
+    # debug output, which logs full request URLs and would defeat the point of
+    # keeping CURIEs and URLs out of the verbose messages below.
     logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.WARNING,
+        level=logging.WARNING,
         format="%(levelname)s %(name)s: %(message)s",
         force=True,
     )
+    logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
 
     # Load environment variables from .env file
     load_dotenv(env_file)


### PR DESCRIPTION
Raised on https://github.com/microbiomedata/external-metadata-awareness/pull/507 and never addressed. Found by sweeping for review threads with no reply, which is a different query from the unresolved-thread audit: this one had been marked resolved without being answered.

`process_document`'s docstring and its code disagreed:

```python
"""Verbose mode emits generic progress messages without logging CURIEs, labels, or URLs."""
...
print(f"Expansion success: {curie} -> {term_uri}")
print(f"Expansion failed for CURIE: {curie}")
```

The docstring is the deliberate side, not the stale one. c91ba00 ("Fix remaining CodeQL logging alerts") rewrote it *from* "Logs a summary message with the CURIE, expansion status, the prefLabel from BioPortal, and mapping details" *to* the current wording, and in the same commit converted `logger.debug(f"Following mappings URL: {mappings_url}")` and `logger.debug(f"BioPortal prefLabel for {curie}: {pref_label}")` to generic messages.

These two survived that cleanup because **CodeQL's logging alerts do not fire on `print()`**. Converting them to `logger.debug` makes all four verbose messages in the function consistent and satisfies the use-logging rule in CLAUDE.md (#203).

Not changed, and worth a separate decision: `fetch_mappings` still does `pprint.pprint(accepted_mappings)` under `--verbose`, which prints CURIEs. That function's docstring makes no claim about logging, so it is not the contradiction reported here, but it is the same shape. The two top-level `print()` calls in `process_documents` ("Found N documents", "Processing complete") carry no identifiers and read as intended CLI output.
