### PR TITLE
Stop --verbose from raising the root logger in mongo-connect

### DIFF
--- a/external_metadata_awareness/mongodb_connection.py
+++ b/external_metadata_awareness/mongodb_connection.py
@@ -158,11 +158,16 @@ def main(uri, env_file, verbose, connect, command):
     # force=True because basicConfig does nothing when handlers already exist,
     # which would leave --verbose silent under a test runner or any importer
     # that configured logging first.
+    # Keep the root at WARNING and raise only this module's logger. Putting the
+    # root at DEBUG switches on pymongo.command and pymongo.connection debug
+    # output, which carries connection details and command payloads, in a
+    # function that deliberately never logs the URI even redacted.
     logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.WARNING,
+        level=logging.WARNING,
         format="%(levelname)s %(name)s: %(message)s",
         force=True,
     )
+    logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
 
     try:
         # Get connection info in dry-run mode if not connecting

--- a/tests/test_mongodb_connection.py
+++ b/tests/test_mongodb_connection.py
@@ -13,6 +13,7 @@ import types
 import pytest
 from click.testing import CliRunner
 
+from external_metadata_awareness import mongodb_connection
 from external_metadata_awareness.mongodb_connection import get_mongo_client, main
 
 _URI = "mongodb://localhost:27017/testdb"
@@ -153,7 +154,24 @@ def test_verbose_wins_over_preconfigured_logging(env_file):
     result = CliRunner().invoke(main, ["--uri", _URI, "--env-file", env_file, "--verbose"])
 
     assert result.exit_code == 0, result.output
-    assert logging.getLogger().level == logging.DEBUG
+    assert mongodb_connection.logger.isEnabledFor(logging.DEBUG)
+
+
+def test_verbose_does_not_enable_third_party_debug(env_file):
+    """--verbose must not raise the root logger.
+
+    Root at DEBUG turns on pymongo.command and pymongo.connection, which carry
+    connection details and command payloads, in a module that deliberately
+    never logs the URI even redacted.
+    """
+    logging.basicConfig(level=logging.WARNING)
+
+    result = CliRunner().invoke(main, ["--uri", _URI, "--env-file", env_file, "--verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger().level == logging.WARNING
+    for name in ("pymongo", "pymongo.command", "pymongo.connection", "urllib3"):
+        assert not logging.getLogger(name).isEnabledFor(logging.DEBUG), name
 
 
 def test_dry_run_cli_reports_on_stdout(env_file):


### PR DESCRIPTION
Same defect Copilot found on https://github.com/microbiomedata/external-metadata-awareness/pull/537, in code I added in https://github.com/microbiomedata/external-metadata-awareness/pull/529 that is already on main.

`--verbose` set the **root** logger to DEBUG. That switches on every library logger too:

```
pymongo                DEBUG enabled : True
pymongo.command        DEBUG enabled : True
pymongo.connection     DEBUG enabled : True
urllib3                DEBUG enabled : True
```

`pymongo.command` and `pymongo.connection` carry command payloads and connection details, inside a function that deliberately never logs the URI even redacted ("Avoid logging connection URIs, even redacted ones, to keep credentials and infrastructure details out of logs"). So `--verbose` quietly undid that.

The root now stays at WARNING and only this module's logger is raised. After:

```
module logger DEBUG enabled : True
pymongo                DEBUG enabled : False
pymongo.command        DEBUG enabled : False
pymongo.connection     DEBUG enabled : False
urllib3                DEBUG enabled : False
root level             : 30 (WARNING)
```

`test_verbose_wins_over_preconfigured_logging` asserted on the root level, which is the behavior being changed, so it now asserts the module logger is enabled instead. `test_verbose_does_not_enable_third_party_debug` pins the new guarantee and fails against main.
