### PR TITLE
Take the GitHub token from gh and drop four env names nothing reads

### DIFF
--- a/Makefiles/github.Makefile
+++ b/Makefiles/github.Makefile
@@ -5,8 +5,17 @@ ifdef ENV_FILE
   ENV_FILE_OPTION := --env-file $(ENV_FILE)
 endif
 
-# GitHub API Token (can be set via GITHUB_TOKEN environment variable)
-ifdef GITHUB_TOKEN
+# GitHub API token. Taken from the gh CLI, which stores it in the macOS Keychain,
+# so no copy is kept in a .env file. An explicit GITHUB_TOKEN still wins if set.
+#
+# ifdef was wrong here: in Make it is true for a variable set to empty, so an empty
+# GITHUB_TOKEN produced "--token " with no value and the command got a malformed flag
+# instead of falling back to unauthenticated.
+# Treat unset and set-but-empty the same way, so both fall back to gh.
+ifeq ($(strip $(GITHUB_TOKEN)),)
+  GITHUB_TOKEN := $(shell gh auth token 2>/dev/null)
+endif
+ifneq ($(strip $(GITHUB_TOKEN)),)
   TOKEN_OPTION := --token $(GITHUB_TOKEN)
 endif
 

--- a/Makefiles/github.Makefile
+++ b/Makefiles/github.Makefile
@@ -11,13 +11,17 @@ endif
 # ifdef was wrong here: in Make it is true for a variable set to empty, so an empty
 # GITHUB_TOKEN produced "--token " with no value and the command got a malformed flag
 # instead of falling back to unauthenticated.
-# Treat unset and set-but-empty the same way, so both fall back to gh.
-ifeq ($(strip $(GITHUB_TOKEN)),)
-  GITHUB_TOKEN := $(shell gh auth token 2>/dev/null)
-endif
-ifneq ($(strip $(GITHUB_TOKEN)),)
-  TOKEN_OPTION := --token $(GITHUB_TOKEN)
-endif
+# Deliberately lazy. `:=` with $(shell ...) runs `gh auth token` every time anything
+# PARSES this file, including tools that only want to inspect it. `=` defers it until a
+# recipe actually expands TOKEN_OPTION, so `make -n`, a linter, or a code scanner reading
+# the Makefile never invokes gh at all.
+#
+# An explicit GITHUB_TOKEN still wins. Unset and set-but-empty are treated the same, since
+# `ifdef` is true for a variable set to empty, which is what produced a malformed
+# "--token " with no value after it.
+GH_TOKEN_FALLBACK = $(shell gh auth token 2>/dev/null)
+EFFECTIVE_TOKEN = $(or $(strip $(GITHUB_TOKEN)),$(strip $(GH_TOKEN_FALLBACK)))
+TOKEN_OPTION = $(if $(EFFECTIVE_TOKEN),--token $(EFFECTIVE_TOKEN),)
 
 # Default values for GitHub repositories
 GITHUB_OWNER ?= microbiomedata

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,7 +320,7 @@ See `mongo-js/` directory for index creation scripts:
 
 **Authentication Handling**:
 - Most scripts: No authentication (localhost only)
-- Some notebooks: `.env` files with `NMDC_MONGO_USER`, `NMDC_MONGO_PASSWORD`
+- Some notebooks: `.env` files with `MONGO_USER`, `MONGO_PASSWORD`
 - `mongodb_connection.py`: Proper auth with `MONGO_USER`, `MONGO_PASSWORD`
 
 **Target State** (from Issue #223):

--- a/docs/makefile-analysis.md
+++ b/docs/makefile-analysis.md
@@ -42,7 +42,7 @@ In nmdc_metadata.Makefile, the target downloads/nmdc_select_mongodb_dump.gz requ
 
 - SSH tunnel to NMDC MongoDB
 - NERSC credentials
-- NMDC MongoDB credentials (NMDC_MONGO_USER and NMDC_MONGO_PASSWORD)
+- NMDC MongoDB credentials (MONGO_USER and MONGO_PASSWORD)
 
 6. Missing Local Directory Structure
 

--- a/docs/nmdc-data-access.md
+++ b/docs/nmdc-data-access.md
@@ -53,6 +53,6 @@ The repo deliberately does not codify the SSH command (NERSC vs. GCP details, ju
 - `make local_nmdc_mongodb_restore`, `make restore-to-{un,}authenticated`, `make nmdc-prod-to-other`, `downloads/nmdc_select_mongodb_dump.gz` — dump/restore of an NMDC Mongo via the NERSC SSH tunnel
 - `make export-nmdc-{duckdb,parquet}`, `make export-flattened-biosample-csv` — DuckDB/parquet/CSV exports of flattened NMDC collections
 - `docs/nmdc-flattening-lakehouse-export.md` — documented the chain above; now described upstream in `kbase/data-lakehouse-ingest`
-- `NMDC_MONGO_USER` / `NMDC_MONGO_PASSWORD` slots in `local/.env.template`
+- `MONGO_USER` / `MONGO_PASSWORD` slots in `local/.env.template`
 
 For historical context see `docs/biosample-flattening-timeline-2020-2025.md` and the retrospective sections of `docs/pipeline-rebuild-pain-points.md`.

--- a/docs/nmdc-prod-mongo-tunnel.md
+++ b/docs/nmdc-prod-mongo-tunnel.md
@@ -18,7 +18,7 @@ This is the connection EMA tools use for realized prod biosamples, for example
    infrastructure lead). Put the username and password in a git-ignored `.env`
    under one of the key pairs EMA tools read, in order:
    `MONGO_USER`/`MONGO_PASSWORD`, then `SOURCE_MONGO_USER`/`SOURCE_MONGO_PASS`,
-   then `NMDC_MONGO_USER`/`NMDC_MONGO_PASSWORD`. Never commit the `.env`.
+   then `MONGO_USER`/`MONGO_PASSWORD`. Never commit the `.env`.
 
 ## Open the tunnel
 

--- a/local/.env.template
+++ b/local/.env.template
@@ -1,7 +1,3 @@
-CBORG_API_KEY=
-GCP_PROJECT_NAME=
-GITHUB_TOKEN=
-OPEN_AI_KEY=
 
 # see https://cborg.lbl.gov/api_examples/
 # does not include gemini yet
@@ -16,3 +12,7 @@ MONGO_PASSWORD=
 
 # Required by env-triad annotation pipeline
 BIOPORTAL_API_KEY=
+
+
+# GITHUB_TOKEN is deliberately absent. Makefiles/github.Makefile reads it from
+# `gh auth token`, so the credential stays in the macOS Keychain rather than a file.


### PR DESCRIPTION
`local/.env` carried nine variables. Six were doing no work, and two of those were
actively misleading.

## Why

`NMDC_MONGO_USER` and `NMDC_MONGO_PASSWORD` held the same values as `MONGO_USER` and
`MONGO_PASSWORD`. `MONGO_CRED_KEY_PAIRS` tries the unprefixed pair first, so the prefixed
pair was never reached. Four documents still pointed at the prefixed names, and
`docs/nmdc-data-access.md` described them as slots in `local/.env.template`, which they
never were.

`CBORG_API_KEY` and `OPEN_AI_KEY` are read by no file in this repo.

`GCP_PROJECT_NAME` and `GITHUB_TOKEN` were declared but empty, which is worse than being
absent. `os.environ.get` returns `""` rather than `None` for a variable set to empty, so
`bigquery.Client(project="")` fails where `project=None` would have used the default
project.

`GITHUB_TOKEN` now comes from `gh auth token`, so the credential stays in the macOS
Keychain instead of being copied into a file. The old `ifdef` was a bug rather than a
preference: in Make, `ifdef` is true for a variable set to empty, so an empty
`GITHUB_TOKEN` produced `--token ` with nothing after it and the command received a
malformed flag instead of falling back to unauthenticated.

## No action needed from anyone

`MONGO_CRED_KEY_PAIRS` is unchanged on purpose. If your `local/.env` still uses the
prefixed names, it keeps working. One of its entries points at `nmdc-schema`, which is not
this repo's to change.

## Tested

- `connect_mongo` authenticates against local MongoDB with the trimmed `local/.env` and
  lists 7 databases.
- `Makefiles/github.Makefile` resolves a 40 character token when `GITHUB_TOKEN` is unset,
  and also when it is set to empty, which the previous version did not handle.
- An explicitly supplied `GITHUB_TOKEN` still takes precedence.
- With no `gh` on `PATH`, no `--token` flag is emitted at all, rather than a broken one.
- `--token` with an empty value no longer appears in any of those cases.
