### PR TITLE
Ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,12 @@ local/
 *.log
 notebooks/mixs_preferred_units/ncbi_metadata.biosamples_measurements_flattened.json
 
-# uv writes this and nothing here reads it. Never tracked in this repo.
+# Both written by one `uv run` on 2026-08-11. Neither was wanted here, and nothing
+# in the Makefiles, CI, or docs reads either one.
 uv.lock
+
+# .venv is currently ignored only by a .gitignore that uv wrote INSIDE it, which
+# disappears when the directory is removed. A venv made by `python -m venv` or by
+# poetry writes no such file and would be fully stageable. Verified by probe:
+# `mkdir .venv-probe/bin && touch .venv-probe/bin/python` shows up in `git status`.
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ local/
 # generated outputs / logs (issue #478)
 *.log
 notebooks/mixs_preferred_units/ncbi_metadata.biosamples_measurements_flattened.json
+
+# uv writes this and nothing here reads it. Never tracked in this repo.
+uv.lock


### PR DESCRIPTION
An untracked `uv.lock` has been sitting in the working tree since 2026-08-11. It has never been tracked here, in any branch, at any point in history, and nothing in the Makefiles, CI, or docs reads it.

Because it was not ignored, any `git add -A` would sweep it into an unrelated pull request.

This matches the convention already settled next door: nmdc-schema ignores `uv.lock` and enforces it in CI, per https://github.com/microbiomedata/nmdc-schema/pull/3319 which merged 2026-08-10.

No `git rm --cached` is needed, since the file was never tracked.